### PR TITLE
Removed job id from the delete command

### DIFF
--- a/src/automations/JobPost.ts
+++ b/src/automations/JobPost.ts
@@ -123,7 +123,7 @@ export default class JobPost {
 
         const locationInfoList = response["features"];
         if (!locationInfoList || !locationInfoList.length)
-            throw new Error("Location infomation cannot be found.");
+            throw new Error(`Location infomation cannot be found fo ${cityName}.`);
         const locationInfo = locationInfoList[0];
         const countryInfo = locationInfo["context"].find((info: any) =>
             info["id"].includes("country")

--- a/src/common/regions.ts
+++ b/src/common/regions.ts
@@ -112,7 +112,7 @@ export const regions: { [key: string]: string[] } = {
         "Home based - Europe, Lyon",
         "Home based - Europe, Madrid",
         "Home based - Europe, Manchester",
-        "Home based - Europe, Marousi # Athens",
+        "Home based - Europe, Marousi",
         "Home based - Europe, Milan",
         "Home based - Europe, Moscow",
         "Home based - Europe, Munich",

--- a/src/index.ts
+++ b/src/index.ts
@@ -184,7 +184,7 @@ async function addPosts(
 async function deletePosts(
     isInteractive: boolean,
     jobPostIDArg: number,
-    regionsArg: string[],
+    regionsArg: string[]
 ) {
     const spinner = ora();
     const sso = new SSO(spinner);
@@ -355,11 +355,7 @@ async function main() {
             new Option("-i, --interactive", "Enable interactive interface")
         )
         .action(async (jobPostID, options) => {
-            await deletePosts(
-                options.interactive,
-                jobPostID,
-                options.regions,
-            );
+            await deletePosts(options.interactive, jobPostID, options.regions);
         });
 
     program

--- a/src/index.ts
+++ b/src/index.ts
@@ -329,10 +329,9 @@ async function main() {
     program
         .command("delete-posts")
         .usage(
-            "([-i | --interactive] | <job-id> --regions=<region-name>[, <region-name-2>...]" +
-                " [--similar=<job-post-id>]) \n\n Examples: \n\t ght delete-posts --interactive " +
-                "\n\t ght delete-posts 1234 --regions=emea,americas \n\t ght delete-posts " +
-                "1234 --regions=emea --similar=1123"
+            "([-i | --interactive] | <job-id> --regions=<region-name>[, <region-name-2>...])" +
+                " \n\n Examples: \n\t greenhouse delete-posts --interactive " +
+                "\n\t greenhouse delete-posts 1234 --regions=emea,americas"
         )
         .description("Delete job posts of the given job")
         .addArgument(


### PR DESCRIPTION
## Done
- Replaced job-id argument with job post id 
- Removed "similar" option
- Updated help text of the "delete-posts" command

## QA
- Checkout the feature branch
- Install dependencies with `yarn` command
- Run ` ts-node ./src/index.ts replicate <post-id> -r emea` command to add job posts
- Verify posts are created from the job posts page
- Run `ts-node ./src/index.ts delete-posts <post-id> -r emea` command to delete job posts
- Verify posts are deleted from the job posts page
- Run `ts-node ./src/index.ts delete-posts -h`
- Verify help text is correct

Fixes https://github.com/canonical/ght/issues/78