### PR TITLE
Removed delete command from the help text

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -307,8 +307,18 @@ async function main() {
             "interactions with the Canonical Greenhouse website."
     );
 
-    program
-        .command("replicate")
+    const replicateCommand = program.command("replicate");
+    const deletePostsCommand = program.command("delete-posts");
+    const loginCommand = program.command("login");
+    const logoutCommand = program.command("logout");
+
+    program.configureHelp({
+        visibleCommands: () => {
+            return [replicateCommand, loginCommand, logoutCommand]
+        }
+    });
+
+    replicateCommand
         .usage(
             "([-i | --interactive] | <job-post-id> --regions=<region-name>[, <region-name-2>...])" +
                 "\n\n Examples: \n\t ght replicate --interactive " +
@@ -341,8 +351,7 @@ async function main() {
             await addPosts(options.interactive, jobPostID, options.regions);
         });
 
-    program
-        .command("delete-posts")
+    deletePostsCommand
         .usage(
             "([-i | --interactive] | <job-id> --regions=<region-name>[, <region-name-2>...])" +
                 " \n\n Examples: \n\t greenhouse delete-posts --interactive " +
@@ -372,15 +381,13 @@ async function main() {
             await deletePosts(options.interactive, jobPostID, options.regions);
         });
 
-    program
-        .command("login")
+    loginCommand
         .description("Login and save credentials")
         .action(async () => {
             await login();
         });
 
-    program
-        .command("logout")
+    logoutCommand
         .description("Remove saved credentials")
         .action(() => {
             logout();

--- a/src/index.ts
+++ b/src/index.ts
@@ -314,8 +314,8 @@ async function main() {
 
     program.configureHelp({
         visibleCommands: () => {
-            return [replicateCommand, loginCommand, logoutCommand]
-        }
+            return [replicateCommand, loginCommand, logoutCommand];
+        },
     });
 
     replicateCommand
@@ -381,17 +381,13 @@ async function main() {
             await deletePosts(options.interactive, jobPostID, options.regions);
         });
 
-    loginCommand
-        .description("Login and save credentials")
-        .action(async () => {
-            await login();
-        });
+    loginCommand.description("Login and save credentials").action(async () => {
+        await login();
+    });
 
-    logoutCommand
-        .description("Remove saved credentials")
-        .action(() => {
-            logout();
-        });
+    logoutCommand.description("Remove saved credentials").action(() => {
+        logout();
+    });
 
     await program.parseAsync(process.argv);
 }


### PR DESCRIPTION
## Done
- Removed delete command from the help text

## QA
- Checkout the feature branch
- Install dependencies with `yarn`
- Run `ts-node ./src/index.ts -h` command
- Verify "delete-posts" does not exist
-  Run `ts-node ./src/index.ts replicate -h` command
- Verify displays the description correctly

Fixes #85 