### PR TITLE
Added recruiter check

### DIFF
--- a/src/automations/Job.ts
+++ b/src/automations/Job.ts
@@ -265,16 +265,14 @@ export default class Job {
     }
 
     private async isRecruiter(parentElement: Puppeteer.ElementHandle) {
-        let isRecruiter = false;
         const tags = await parentElement.$$(".job-tag");
         for (const tag of tags) {
             const tagText = await getInnerText(tag);
             if (RECRUITER === tagText.toLocaleUpperCase()) {
-                isRecruiter = true;
-                break;
+                return true
             }
         }
-        return isRecruiter;
+        return false;
     }
 
     private async loadAllJobs() {

--- a/src/automations/Job.ts
+++ b/src/automations/Job.ts
@@ -269,7 +269,7 @@ export default class Job {
         for (const tag of tags) {
             const tagText = await getInnerText(tag);
             if (RECRUITER === tagText.toLocaleUpperCase()) {
-                return true
+                return true;
             }
         }
         return false;
@@ -329,8 +329,7 @@ export default class Job {
 
             const jobIDFromCell = await getIDFromURL(nameCell, "a");
             if (jobIDFromCell === jobID) {
-                const isRecruiter = await this.isRecruiter(jobElement);
-                return isRecruiter;
+                return await this.isRecruiter(jobElement);
             }
         }
         return false;

--- a/src/automations/Job.ts
+++ b/src/automations/Job.ts
@@ -4,7 +4,7 @@ import {
     JOB_BOARD,
     MAIN_URL,
     PROTECTED_JOB_BOARDS,
-    RECUITER,
+    RECRUITER,
 } from "../common/constants";
 import { getIDFromURL, getInnerText, joinURL } from "../common/pageUtils";
 import { regions } from "../common/regions";
@@ -265,16 +265,16 @@ export default class Job {
     }
 
     private async isRecruiter(parentElement: Puppeteer.ElementHandle) {
-        let isRecuiter = false;
+        let isRecruiter = false;
         const tags = await parentElement.$$(".job-tag");
         for (const tag of tags) {
             const tagText = await getInnerText(tag);
-            if (RECUITER === tagText.toLocaleUpperCase()) {
-                isRecuiter = true;
+            if (RECRUITER === tagText.toLocaleUpperCase()) {
+                isRecruiter = true;
                 break;
             }
         }
-        return isRecuiter;
+        return isRecruiter;
     }
 
     private async loadAllJobs() {
@@ -302,8 +302,8 @@ export default class Job {
             const jobNameElement = await jobElement.$(".job-label-name");
             if (!jobNameElement) throw new Error("Cannot get job name");
 
-            const isRecuiter = await this.isRecruiter(jobElement);
-            if (!isRecuiter) continue;
+            const isRecruiter = await this.isRecruiter(jobElement);
+            if (!isRecruiter) continue;
 
             const nameCell = await jobElement.$(".job-name");
             if (!nameCell) throw new Error("Cannot get job name cell.");
@@ -331,8 +331,8 @@ export default class Job {
 
             const jobIDFromCell = await getIDFromURL(nameCell, "a");
             if (jobIDFromCell === jobID) {
-                const isRecuiter = await this.isRecruiter(jobElement);
-                return isRecuiter;
+                const isRecruiter = await this.isRecruiter(jobElement);
+                return isRecruiter;
             }
         }
         return false;

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -47,4 +47,4 @@ export const FILTERED_ATTRIBUTES = [
 
 export const PROTECTED_JOB_BOARDS = ["Canonical", "Internal"];
 
-export const RECUITER = "RECRUITER";
+export const RECRUITER = "RECRUITER";

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,13 +143,16 @@ async function addPosts(
 
             spinner.start(`Fetching the job information.`);
             jobID = await job.getJobIDFromPost(postIDArg);
-            jobInfo = await job.getJobData(jobID);
-            spinner.succeed();
 
-            if (jobInfo.posts.length === 0)
+            const hasAccess = await job.hasAccess(jobID);
+            if (!hasAccess)
                 throw Error(
                     "Only hiring leads can create job posts. If you are not sure about your hiring role please contact HR."
                 );
+            jobInfo = await job.getJobData(jobID);
+            spinner.succeed();
+
+            if (jobInfo.posts.length === 0) throw Error("No job post found.");
         }
         // Process updates for each 'Canonical' job unless a "clone-from" argument is passed
         const clonedJobPosts = await job.clonePost(
@@ -231,13 +234,13 @@ async function deletePosts(
         } else {
             spinner.start(`Fetching the job information.`);
             jobID = await job.getJobIDFromPost(postID);
-            jobInfo = await job.getJobData(jobID);
-            spinner.succeed();
-
-            if (jobInfo.posts.length === 0)
+            const hasAccess = await job.hasAccess(jobID);
+            if (!hasAccess)
                 throw Error(
                     "Only hiring leads can delete job posts. If you are not sure about your hiring role please contact HR."
                 );
+            jobInfo = await job.getJobData(jobID);
+            spinner.succeed();
         }
         await job.deletePosts(jobInfo, regionNames, postID);
 


### PR DESCRIPTION
## Done
- Recruiter check is added to "replicate" and "delete-posts" commands.

## QA
- Checkout the feature branch.
- Install dependencies with `yarn`
- Find a job without a "Recruiter" tag from Greenhouse
- Find a job post for the job that is in the "Canonical" board
- Copy the id of it
- Run `ts-node ./src/index.ts replicate <job-post-id> -r emea`
- Verify "Only hiring leads can add job posts. If you are not sure about your hiring role please contact HR." is printed.
- Run `ts-node ./src/index.ts delete-posts <job-post-id> -r emea`
- Verify "Only hiring leads can delete job posts. If you are not sure about your hiring role please contact HR." is printed.
- Find a job with a "Recruiter" tag from Greenhouse
- Find a job post for the job that is in the "Canonical" board
- Copy the id of it
- Run `ts-node ./src/index.ts replicate <job-post-id> -r emea`
- Verify job posts are created
- Run `ts-node ./src/index.ts delete-posts <job-post-id> -r emea`
- Verify job posts are deleted

Fixes #88 