### PR TITLE
EEOC should be set to false if the city is not in the USA

### DIFF
--- a/src/automations/JobPost.ts
+++ b/src/automations/JobPost.ts
@@ -253,9 +253,8 @@ export default class JobPost {
 
         // set the eeoc value if the location is in the USA
         const isInUSA = usaCities.find((city: string) => location === city);
-        if (isInUSA) {
-            jobApplication["enable_eeoc"] = true;
-        }
+        jobApplication["enable_eeoc"] = isInUSA;
+        
 
         // Fill free job post board information, enable Indeed posts
         jobApplication["job_board_feed_settings_attributes"] = [


### PR DESCRIPTION
## Done
The EEOC is set to true if the city is in the USA. Otherwise, it is set to false.

## QA
- Checkout the feature branch
- Install dependencies with `yarn`
- Find a job that is in the "Canonical" board and has "EEOC" checkbox that is checked 
- Run `yarn dev replicate -i`
- Select the job that matches with the criteria
- Choose 'emea'
- Verify the created job posts' "EEOC" checkbox are not checked.
-  Run `yarn dev delete-posts -i` to delete posts.
- Run `yarn dev replicate -i`
- Select the job that matches with the criteria
- Choose 'americas'
- Verify the created job posts' "EEOC" checkbox are checked.
- Run `yarn dev delete-posts -i` to delete posts.

Fixes #106  
