### PR TITLE
Added recruiter check for interactive mode

### DIFF
--- a/src/automations/Job.ts
+++ b/src/automations/Job.ts
@@ -4,6 +4,7 @@ import {
     JOB_BOARD,
     MAIN_URL,
     PROTECTED_JOB_BOARDS,
+    RECRUITER,
     TEST_JOB_BOARD,
 } from "../common/constants";
 import { getIDFromURL, getInnerText, joinURL } from "../common/pageUtils";

--- a/src/automations/Job.ts
+++ b/src/automations/Job.ts
@@ -256,13 +256,26 @@ export default class Job {
 
         return await evaluate(
             this.page,
-            ({ htmlAsStr }) => {
+            ({ htmlAsStr, recruiterTag }) => {
                 const domParser = new DOMParser();
                 const root = domParser.parseFromString(htmlAsStr, "text/html");
                 const jobElements = root.querySelectorAll("a.target");
                 const jobInfo: { [jobName: string]: number } = {};
                 for (const item of jobElements) {
                     if (item.getAttribute("title")) {
+                        const tags = item.querySelectorAll(".job-tag.role");
+                        let isRecruiter = false;
+                        for (const tag of tags) {
+                            const recruiterCheck = tag.innerHTML.match(
+                                new RegExp(recruiterTag, "i")
+                            );
+                            if (recruiterCheck) {
+                                isRecruiter = true;
+                                break;
+                            }
+                        }
+
+                        if (!isRecruiter) continue;
                         const url = item.getAttribute("href");
                         if (!url) throw new Error(`Cannot get ID from ${url}.`);
                         const urlParts: string[] = url.split("/");
@@ -278,7 +291,10 @@ export default class Job {
                 }
                 return jobInfo;
             },
-            { htmlAsStr: JSON.parse(decodeURIComponent(innerHTML))["html"] }
+            {
+                htmlAsStr: JSON.parse(decodeURIComponent(innerHTML))["html"],
+                recruiterTag: RECRUITER,
+            }
         );
     }
 

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -49,3 +49,4 @@ export const FILTERED_ATTRIBUTES = [
 export const PROTECTED_JOB_BOARDS = ["Canonical", "Internal"];
 
 export const USER_ERROR = "UserError";
+export const RECRUITER = "RECRUITER";


### PR DESCRIPTION
## Done
- Added recruiter check for interactive mode

## QA
- Find a job that the recruiter tag does not exist but can be edited
- Run `yarn dev replicate <job-post-id>` 
- Verify job posts are created
- Run `yarn dev replicate -i`
- Verify jobs that have recruiter tag displayed 

Fixes #120