### PR TITLE
Retrieved job information from the list URL

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
         "outDir": "dist",
         "lib": [
             "es2016",
-            "dom"
+            "dom",
+            "dom.iterable"
         ]
     },
     "include": ["src"],


### PR DESCRIPTION
## Done
- Instead of collecting job information from the greenhouse UI, an URL that returns JSON is used.

## QA
- Checkout the feature branch
- Install dependencies with `yarn`
- Run `yarn dev replicate -i` command
- Verify all the jobs are listed
- Select the necessary information and continue
- Verify job posts are created.
- Run `yarn dev delete-posts -i` command
- Verify all the jobs are listed
- Select the necessary information and continue
- Verify job posts are deleted.

Fixes #122 