### PR TITLE
Load all pages

### DIFF
--- a/src/automations/Job.ts
+++ b/src/automations/Job.ts
@@ -301,7 +301,7 @@ export default class Job {
 
         return {
             jobs,
-            hasMorePage: !!content["pagination"].replace(/\n/g, ""),
+            hasMorePage: !!content["pagination"]?.replace(/\n/g, ""),
         };
     }
 


### PR DESCRIPTION
## Done
- Removed a check that checks if more page should loaded according to found "Recruiter" tagged jobs.
- 'pagination' field is checked to find the last page.

## QA
- Checkout the feature branch
- Install dependencies with `yarn`
- Set headless false to make puppeteer to run in headful mode
   - Open 'SSO.ts'
   - Go to authenticate function
   - Update `const browser = await Puppeteer.launch({ args: ["--no-sandbox"] });` to `const browser = await Puppeteer.launch({ args: ["--no-sandbox"], headless: false });`
- Run `yarn dev replicate -i`
- Verify all jobs are listed.
- Verify all pages are iterated. 
  - When the jobs are listed in the command line, check the Chromium.
  - Verify the "pagination" field in the browser is '\n'
  
![image](https://user-images.githubusercontent.com/24393395/162384650-cbc5cad2-1d51-4ae1-b76d-059ee5b4ef8b.png)
 
Fixes #130 