### PR TITLE
Removed resume_required field from the filtered attributes list

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -31,7 +31,6 @@ export const FILTERED_ATTRIBUTES = [
     "all_office_ids",
     "office_ids",
     "questions_for_api",
-    "resume_required",
     "compliance",
     "data_compliance",
     "departments",


### PR DESCRIPTION
## Done
- Removed resume_required field from the filtered attributes list

## QA
- Checkout the feature branch
- Create a job post in the "Canonical" board
- Update "Resume" field to "Required"
- Run `yarn dev replicate -i`
- Select the job
- Select the created job post
- Select other required fields
- Verify copied job posts have a required resume field.
- Update the original job post's "Resume" field to "Optional"
- Run `yarn dev replicate -i`
- Select the job
- Select the created job post
- Select other required fields
- Verify copied job posts have an optional resume field.

Fixes https://github.com/canonical/ght/issues/143