### PR TITLE
Assign random written interview graders

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,27 @@ If you want to use the interactive mode you can run the command with the flag `-
 ght replicate -i
 ```
 
+### Assign graders to written interviews
+
+You can use `ght` to assign random graders to written interviews. You should have a `ght-graders.yml` file in your home directory with the format:
+
+```
+Job name 1:
+  Written Interview:
+    - name: Grader One
+      active: true
+    - name: Grader Two
+      active: false
+    - name: Grader Three
+      active: true
+Job name 2:
+  Written Interview:
+    - name: Grader Four
+      active: true
+```
+
+Running `ght assign -i` will guide you through the process of selecting the jobs. For the selected jobs, it will go through the written interviews needing graders (applications where only the hiring lead is assigned, since this is the default behaviour in Greenhouse) and will assign two random names from the list provided.
+
 ### Authentication
 
 The CLI will manage authentication. To avoid entering credentials every time the command runs, the authorization cookie created by Greenhouse and SSO will be stored in the file:  `~/.canonical-greenhouse.json`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ght",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "scripts": {
         "build": "tsc && cp package.json ght ./dist",
         "dev": "NODE_ENV=development ts-node ./src/index.ts",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "commander": "9.1.0",
         "enquirer": "2.3.6",
         "http-cookie-agent": "1.0.5",
+        "js-yaml": "^4.1.0",
         "jsdom": "19.0.0",
         "node-fetch": "2.6.7",
         "ora": "5.4.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "devDependencies": {
         "@tsconfig/node16": "1.0.2",
         "@types/colors": "1.2.1",
+        "@types/js-yaml": "^4.0.5",
         "@types/jsdom": "16.2.14",
         "@types/node": "17.0.14",
         "@types/node-fetch": "2.6.1",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ght
-version: "1.1.0"
+version: "1.2.0"
 summary: Perform actions in Canonical's Greenhouse automatically.
 description: An automated browser that does a set of tasks on Canonical's Greenhouse dashboard without the need of interaction with the UI.
 base: core20

--- a/src/assign-graders/LoadBalancer.ts
+++ b/src/assign-graders/LoadBalancer.ts
@@ -14,6 +14,7 @@ export default class LoadBalancer {
     private graders: Grader[];
     private jobs: string[];
     private spinner: Ora;
+    private currentUser: string = "";
 
     constructor(
         page: Page,
@@ -45,7 +46,7 @@ export default class LoadBalancer {
                     .trim();
                 const candidate = p.querySelector(".name a")?.textContent;
 
-                if (applicationID && candidate && job && toGrade) {
+                if (applicationID && candidate && job && toGrade != null) {
                     return {
                         applicationID,
                         candidate,
@@ -55,35 +56,6 @@ export default class LoadBalancer {
                 }
             })
         );
-    }
-
-    /**
-     * Get applications to process one at a time
-     */
-    private async *getApplicationsToProcess() {
-        while (true) {
-            await this.page.waitForSelector(".person");
-            const applicationsPage = await this.getApplicationsPage();
-
-            for (const application of applicationsPage) {
-                if (
-                    application &&
-                    application?.toGrade &&
-                    this.jobs.includes(application.job)
-                ) {
-                    yield application;
-                }
-            }
-
-            // Keep doing this until there are no more pages
-            const nextPageBtn = await this.page.$("a.next_page:not(.disabled)");
-            if (!nextPageBtn) return;
-
-            await Promise.all([
-                this.page.waitForNavigation(),
-                nextPageBtn.click(),
-            ]);
-        }
     }
 
     /**
@@ -124,9 +96,87 @@ export default class LoadBalancer {
      * Find current user name in UI
      */
     private async findUsername() {
-        return await this.page.$eval(
+        const currentUser = await this.page.$eval(
             "script[data-user-name]",
             (el) => (el as HTMLElement).dataset.userName
+        );
+        if (!currentUser) {
+            throw new Error("Unable to find user's name in Greenhouse");
+        }
+        this.currentUser = currentUser;
+    }
+
+    /**
+     * Assign graders to one application
+     */
+    private async assignGradersToApplication(application: Application) {
+        this.spinner.start("Processing applications");
+
+        const selector = `.person[application="${application?.applicationID}"]`;
+
+        // Click toggle button
+        await this.page.waitForSelector(`${selector} .toggle-interviews`);
+        await this.page.$eval(`${selector} .toggle-interviews`, (toggle) =>
+            (toggle as HTMLAnchorElement).click()
+        );
+
+        // Click edit
+        await this.page.waitForSelector(
+            `${selector} .edit-take-home-test-graders-link`
+        );
+
+        await this.page.$eval(
+            `${selector} .edit-take-home-test-graders-link`,
+            (btn) => (btn as HTMLAnchorElement).click()
+        );
+
+        // Wait for modal to open
+        await this.page.waitForSelector("ul.chzn-choices", {
+            visible: true,
+        });
+
+        // Read graders already assigned
+        const gradersAssigned = await this.page.$$eval(
+            "ul .search-choice span",
+            (el) => el.map((grader) => grader.textContent)
+        );
+        // Skip if already graders assigned
+        if (gradersAssigned.length >= 2) {
+            return;
+        }
+        // Skip if only one grader but it's not the user
+        if (
+            gradersAssigned.length === 1 &&
+            gradersAssigned[0] !== this.currentUser
+        ) {
+            return;
+        }
+
+        // Click input field
+        await this.page.waitForSelector(".search-field input[type='text']");
+        await this.page.click(".search-field input[type='text']");
+
+        // If there's only one grader and is the user running the command remove it
+        // (hiring leads are assigned by default as graders)
+        if (
+            gradersAssigned.length === 1 &&
+            gradersAssigned[0] === this.currentUser
+        ) {
+            await this.page.keyboard.press("Backspace");
+            await this.page.keyboard.press("Backspace");
+        }
+
+        const [grader1, grader2] = this.findRandomGraders(application);
+        await this.writeGrader(grader1);
+        await this.writeGrader(grader2);
+
+        // Click save
+        await this.page.click("input[type='submit']");
+
+        this.spinner.stop();
+        console.log(
+            green("✔"),
+            `Written Interview from ${application.candidate} assigned to: ${grader1.name}, ${grader2.name}`
         );
     }
 
@@ -134,82 +184,29 @@ export default class LoadBalancer {
         await this.page.goto(
             `${MAIN_URL}people?sort_by=last_activity&sort_order=desc&stage_status_id%5B%5D=2&in_stages%5B%5D=Written+Interview`
         );
+        await this.findUsername();
 
-        const currentUser = await this.findUsername();
-        if (!currentUser) {
-            throw new Error("Unable to find user's name in Greenhouse");
+        while (true) {
+            await this.page.waitForSelector(".person");
+            const applicationsPage = await this.getApplicationsPage();
+            for (const application of applicationsPage) {
+                if (
+                    application &&
+                    application?.toGrade &&
+                    this.jobs.includes(application.job)
+                ) {
+                    await this.assignGradersToApplication(application);
+                }
+            }
+
+            // Keep doing this until there are no more pages
+            const nextPageBtn = await this.page.$("a.next_page:not(.disabled)");
+            if (!nextPageBtn) break;
+
+            await Promise.all([
+                this.page.waitForNavigation(),
+                nextPageBtn.click(),
+            ]);
         }
-
-        this.spinner.start("Processing applications\n");
-
-        for await (const application of this.getApplicationsToProcess()) {
-            const selector = `.person[application="${application?.applicationID}"]`;
-
-            // Click toggle button
-            await this.page.waitForSelector(`${selector} .toggle-interviews`);
-            await this.page.$eval(`${selector} .toggle-interviews`, (toggle) =>
-                (toggle as HTMLAnchorElement).click()
-            );
-
-            // Click edit
-            await this.page.waitForSelector(
-                `${selector} .edit-take-home-test-graders-link`
-            );
-
-            await this.page.$eval(
-                `${selector} .edit-take-home-test-graders-link`,
-                (btn) => (btn as HTMLAnchorElement).click()
-            );
-
-            // Wait for modal to open
-            await this.page.waitForSelector("ul.chzn-choices", {
-                visible: true,
-            });
-
-            // Read graders already assigned
-            const gradersAssigned = await this.page.$$eval(
-                "ul .search-choice span",
-                (el) => el.map((grader) => grader.textContent)
-            );
-            // Skip if already graders assigned
-            if (gradersAssigned.length >= 2) {
-                continue;
-            }
-            // Skip if only one grader but it's not the user
-            if (
-                gradersAssigned.length === 1 &&
-                gradersAssigned[0] !== currentUser
-            ) {
-                continue;
-            }
-
-            // Click input field
-            await this.page.waitForSelector(".search-field input[type='text']");
-            await this.page.click(".search-field input[type='text']");
-
-            // If there's only one grader and is the user running the command remove it
-            // (hiring leads are assigned by default as graders)
-            if (
-                gradersAssigned.length === 1 &&
-                gradersAssigned[0] === currentUser
-            ) {
-                await this.page.keyboard.press("Backspace");
-                await this.page.keyboard.press("Backspace");
-            }
-
-            const [grader1, grader2] = this.findRandomGraders(application);
-            await this.writeGrader(grader1);
-            await this.writeGrader(grader2);
-
-            // Click save
-            await this.page.click("input[type='submit']");
-
-            console.log(
-                green("✔"),
-                `Written Interview from ${application.candidate} assigned to: ${grader1.name}, ${grader2.name}`
-            );
-        }
-
-        this.spinner.stop();
     }
 }

--- a/src/assign-graders/LoadBalancer.ts
+++ b/src/assign-graders/LoadBalancer.ts
@@ -161,7 +161,6 @@ export default class LoadBalancer {
                 `${selector} .edit-take-home-test-graders-link`
             );
 
-            console.log("found");
             await this.page.$eval(
                 `${selector} .edit-take-home-test-graders-link`,
                 (btn) => (btn as HTMLAnchorElement).click()
@@ -177,8 +176,15 @@ export default class LoadBalancer {
                 "ul .search-choice span",
                 (el) => el.map((grader) => grader.textContent)
             );
-            // Skip if already two graders assigned
+            // Skip if already graders assigned
             if (gradersAssigned.length >= 2) {
+                continue;
+            }
+            // Skip if only one grader but it's not the user
+            if (
+                gradersAssigned.length === 1 &&
+                gradersAssigned[0] !== currentUser
+            ) {
                 continue;
             }
 

--- a/src/assign-graders/LoadBalancer.ts
+++ b/src/assign-graders/LoadBalancer.ts
@@ -208,5 +208,7 @@ export default class LoadBalancer {
                 `Written Interview from ${application.candidate} assigned to: ${grader1.name}, ${grader2.name}`
             );
         }
+
+        this.spinner.stop();
     }
 }

--- a/src/assign-graders/LoadBalancer.ts
+++ b/src/assign-graders/LoadBalancer.ts
@@ -1,9 +1,9 @@
+import { Application, Grader } from "./types";
+import { MAIN_URL } from "../common/constants";
+import UserError from "../common/UserError";
 import { green } from "colors";
 import { Ora } from "ora";
 import { Page } from "puppeteer";
-import { MAIN_URL } from "../common/constants";
-import UserError from "../common/UserError";
-import { Application, Grader } from "./types";
 
 /**
  * Interact with Greenhouse UI and assign

--- a/src/assign-graders/LoadBalancer.ts
+++ b/src/assign-graders/LoadBalancer.ts
@@ -41,7 +41,7 @@ export default class LoadBalancer {
                 const job = p
                     .querySelector(".job")
                     // Delete requisition ID next to job name
-                    ?.textContent?.replace(/\(\d+\)/, "")
+                    ?.textContent?.replace(/\(\d+\)$/, "")
                     .trim();
                 const candidate = p.querySelector(".name a")?.textContent;
 

--- a/src/assign-graders/LoadBalancer.ts
+++ b/src/assign-graders/LoadBalancer.ts
@@ -45,12 +45,7 @@ export default class LoadBalancer {
                     .trim();
                 const candidate = p.querySelector(".name a")?.textContent;
 
-                if (
-                    applicationID != null &&
-                    candidate != null &&
-                    job != null &&
-                    toGrade != null
-                ) {
+                if (applicationID && candidate && job && toGrade) {
                     return {
                         applicationID,
                         candidate,

--- a/src/assign-graders/LoadBalancer.ts
+++ b/src/assign-graders/LoadBalancer.ts
@@ -1,0 +1,196 @@
+import { Page } from "puppeteer";
+import { MAIN_URL } from "../common/constants";
+import UserError from "../common/UserError";
+import { Application, Grader } from "./types";
+
+/**
+ * Interact with Greenhouse UI and assign
+ * graders to written inteviews
+ */
+export default class LoadBalancer {
+    private page: Page;
+    private graders: Grader[];
+    private jobs: string[];
+
+    constructor(page: Page, graders: Grader[], selectedJobs: string[]) {
+        this.page = page;
+        this.graders = graders;
+        this.jobs = selectedJobs;
+    }
+
+    /**
+     * Return applications in current page
+     */
+    private async getApplicationsPage() {
+        return await this.page.$$eval(".person", (people) =>
+            people.map((p) => {
+                const applicationID = p.getAttribute("application");
+                const toggleText = p.querySelector(
+                    "a.toggle-interviews"
+                )?.textContent;
+                const toGrade = toggleText?.includes("Scorecard due");
+                const job = p
+                    .querySelector(".job")
+                    // Delete requisition ID next to job name
+                    ?.textContent?.replace(/\(\d+\)/, "")
+                    .trim();
+                const candidate = p.querySelector(".name a")?.textContent;
+
+                if (
+                    applicationID != null &&
+                    candidate != null &&
+                    job != null &&
+                    toGrade != null
+                ) {
+                    return {
+                        applicationID,
+                        candidate,
+                        job,
+                        toGrade,
+                    };
+                }
+            })
+        );
+    }
+
+    /**
+     * Get applications to process one at a time
+     */
+    private async *getApplicationsToProcess() {
+        while (true) {
+            await this.page.waitForSelector(".person");
+            const applicationsPage = await this.getApplicationsPage();
+
+            for (const application of applicationsPage) {
+                if (
+                    application &&
+                    application?.toGrade &&
+                    this.jobs.includes(application.job)
+                ) {
+                    yield application;
+                }
+            }
+
+            // Keep doing this until there are no more pages
+            const nextPageBtn = await this.page.$("a.next_page:not(.disabled)");
+            if (!nextPageBtn) return;
+
+            await Promise.all([
+                this.page.waitForNavigation(),
+                nextPageBtn.click(),
+            ]);
+        }
+    }
+
+    /**
+     * Get random grader from array
+     */
+    private getRandom(graders: Grader[]) {
+        return graders[Math.floor(Math.random() * graders.length)];
+    }
+
+    /**
+     * Type grader's name
+     */
+    private async writeGrader(grader: Grader) {
+        await this.page.type(".search-field input[type='text']", grader.name);
+        await this.page.keyboard.press("Enter");
+    }
+
+    /**
+     * Find two random graders for an application
+     */
+    private findRandomGraders(application: Application) {
+        const graders = this.graders.filter(
+            (grader: Grader) => grader.job == application.job
+        );
+        if (graders.length < 2) {
+            throw new UserError("Not enough graders to pick from");
+        }
+        const grader1 = this.getRandom(graders);
+        // Remove first grader so it doesn't get choosen twice
+        const grader2 = this.getRandom(
+            graders.filter((name) => name !== grader1)
+        );
+
+        return [grader1, grader2];
+    }
+
+    /**
+     * Find current user name in UI
+     */
+    private async findUsername() {
+        return await this.page.$eval(
+            "script[data-user-name]",
+            (el) => (el as HTMLElement).dataset.userName
+        );
+    }
+
+    public async execute(): Promise<void> {
+        await this.page.goto(
+            `${MAIN_URL}people?sort_by=last_activity&sort_order=desc&stage_status_id%5B%5D=2&in_stages%5B%5D=Written+Interview`
+        );
+
+        const currentUser = await this.findUsername();
+        if (!currentUser) {
+            throw new Error("Unable to find user's name in Greenhouse");
+        }
+
+        for await (const application of this.getApplicationsToProcess()) {
+            console.log(application);
+            const selector = `.person[application="${application?.applicationID}"]`;
+
+            // Click toggle button
+            await this.page.waitForSelector(`${selector} .toggle-interviews`);
+            await this.page?.click(`${selector} .toggle-interviews`);
+
+            // Click edit
+            await this.page.waitForSelector(
+                `${selector} .edit-take-home-test-graders-link`
+            );
+            await this.page.click(
+                `${selector} .edit-take-home-test-graders-link`
+            );
+
+            // Wait for modal to open
+            await this.page.waitForSelector(
+                "[aria-describedby='edit_take_home_test_graders_modal']"
+            );
+
+            // Read graders already assigned
+            const gradersAssigned = await this.page.$$eval(
+                "ul .search-choice span",
+                (el) => el.map((grader) => grader.textContent)
+            );
+            // Skip if already two graders assigned
+            if (gradersAssigned.length >= 2) {
+                continue;
+            }
+
+            // Click input field
+            await this.page.waitForSelector(".search-field input[type='text']");
+            await this.page.click(".search-field input[type='text']");
+
+            // If there's only one grader and is the user running the command remove it
+            // (hiring leads are assigned by default as graders)
+            if (
+                gradersAssigned.length === 1 &&
+                gradersAssigned[0] === currentUser
+            ) {
+                await this.page.keyboard.press("Backspace");
+                await this.page.keyboard.press("Backspace");
+            }
+
+            const [grader1, grader2] = this.findRandomGraders(application);
+            await this.writeGrader(grader1);
+            await this.writeGrader(grader2);
+
+            console.log(
+                `Written Interview from ${application.candidate} assigned to: ${grader1.name}, ${grader2.name}`
+            );
+
+            // Click save
+            await this.page.click("input[type='submit']");
+        }
+    }
+}

--- a/src/assign-graders/index.ts
+++ b/src/assign-graders/index.ts
@@ -1,10 +1,10 @@
+import LoadBalancer from "./LoadBalancer";
+import { loadConfig, createPool } from "./utils";
 import UserError from "../common/UserError";
 import { runPrompt } from "../common/commandUtils";
 // @ts-ignore This can be deleted after https://github.com/enquirer/enquirer/issues/135 is fixed.
 import { MultiSelect } from "enquirer";
-import LoadBalancer from "./LoadBalancer";
 import Puppeteer from "puppeteer";
-import { loadConfig, createPool } from "./utils";
 import { Ora } from "ora";
 
 export default async function assignGraders(

--- a/src/assign-graders/index.ts
+++ b/src/assign-graders/index.ts
@@ -5,8 +5,10 @@ import { MultiSelect } from "enquirer";
 import LoadBalancer from "./LoadBalancer";
 import Puppeteer from "puppeteer";
 import { loadConfig, createPool } from "./utils";
+import { Ora } from "ora";
 
 export default async function assignGraders(
+    spinner: Ora,
     page: Puppeteer.Page,
     isInteractive: boolean
 ) {
@@ -29,7 +31,12 @@ export default async function assignGraders(
         const selectedJobs: string[] = await runPrompt(prompt);
         const graders = createPool(config, selectedJobs, STAGE);
 
-        const loadBalancer = new LoadBalancer(page, graders, selectedJobs);
+        const loadBalancer = new LoadBalancer(
+            page,
+            graders,
+            selectedJobs,
+            spinner
+        );
         await loadBalancer.execute();
     }
 }

--- a/src/assign-graders/index.ts
+++ b/src/assign-graders/index.ts
@@ -1,0 +1,35 @@
+import UserError from "../common/UserError";
+import { runPrompt } from "../common/commandUtils";
+// @ts-ignore This can be deleted after https://github.com/enquirer/enquirer/issues/135 is fixed.
+import { MultiSelect } from "enquirer";
+import LoadBalancer from "./LoadBalancer";
+import Puppeteer from "puppeteer";
+import { loadConfig, createPool } from "./utils";
+
+export default async function assignGraders(
+    page: Puppeteer.Page,
+    isInteractive: boolean
+) {
+    // Only Written Interview for now
+    const STAGE = "Written Interview";
+
+    // Only interactive mode for now
+    if (isInteractive) {
+        const config = await loadConfig();
+        const jobs = Object.keys(config);
+        if (!jobs.length) throw new UserError("You don't have any job.");
+
+        const prompt = new MultiSelect({
+            name: "Jobs",
+            message:
+                "Choose the jobs you want to assign graders to. Use space to make a selection",
+            choices: jobs,
+            validate: (value: string[]) => value.length > 0,
+        });
+        const selectedJobs: string[] = await runPrompt(prompt);
+        const graders = createPool(config, selectedJobs, STAGE);
+
+        const loadBalancer = new LoadBalancer(page, graders, selectedJobs);
+        await loadBalancer.execute();
+    }
+}

--- a/src/assign-graders/types.ts
+++ b/src/assign-graders/types.ts
@@ -1,0 +1,22 @@
+export type Config = {
+    [job: string]: {
+        [stage: string]: [
+            {
+                name: string;
+                active: boolean;
+            }
+        ];
+    };
+};
+
+export type Grader = {
+    name: string;
+    job: string;
+};
+
+export type Application = {
+    candidate: string;
+    job: string;
+    applicationID: string;
+    toGrade: boolean;
+};

--- a/src/assign-graders/utils.ts
+++ b/src/assign-graders/utils.ts
@@ -9,7 +9,7 @@ import { Config, Grader } from "./types";
  * Load list of graders from config file
  */
 export function loadConfig(): Config {
-    const filePath = join(homedir(), "people.yml");
+    const filePath = join(homedir(), "ght-graders.yml");
     const config = yaml.load(fs.readFileSync(filePath, "utf8"));
 
     return config;

--- a/src/assign-graders/utils.ts
+++ b/src/assign-graders/utils.ts
@@ -1,0 +1,37 @@
+// @ts-ignore
+import yaml from "js-yaml";
+import fs from "fs";
+import { homedir } from "os";
+import { join } from "path";
+import { Config, Grader } from "./types";
+
+/**
+ * Load list of graders from config file
+ */
+export function loadConfig(): Config {
+    const filePath = join(homedir(), "people.yml");
+    const config = yaml.load(fs.readFileSync(filePath, "utf8"));
+
+    return config;
+}
+
+/**
+ * Return list of graders based on selected options
+ */
+export function createPool(
+    config: Config,
+    selectedJobs: string[],
+    stage: string
+) {
+    let pool: Grader[] = [];
+    selectedJobs.forEach((job) => {
+        const activeGraders = config[job][stage].filter(
+            (grader) => grader.active
+        );
+        activeGraders.forEach(({ name }) => {
+            pool.push({ name, job });
+        });
+    });
+
+    return pool;
+}

--- a/src/assign-graders/utils.ts
+++ b/src/assign-graders/utils.ts
@@ -1,8 +1,8 @@
-import fs from "fs";
+import { Config, Grader } from "./types";
 import yaml from "js-yaml";
+import fs from "fs";
 import { homedir } from "os";
 import { join } from "path";
-import { Config, Grader } from "./types";
 
 /**
  * Load list of graders from config file

--- a/src/assign-graders/utils.ts
+++ b/src/assign-graders/utils.ts
@@ -1,6 +1,5 @@
-// @ts-ignore
-import yaml from "js-yaml";
 import fs from "fs";
+import yaml from "js-yaml";
 import { homedir } from "os";
 import { join } from "path";
 import { Config, Grader } from "./types";
@@ -9,8 +8,11 @@ import { Config, Grader } from "./types";
  * Load list of graders from config file
  */
 export function loadConfig(): Config {
-    const filePath = join(homedir(), "ght-graders.yml");
-    const config = yaml.load(fs.readFileSync(filePath, "utf8"));
+    const filePath = join(
+        process.env["SNAP_REAL_HOME"] || homedir(),
+        "ght-graders.yml"
+    );
+    const config = yaml.load(fs.readFileSync(filePath, "utf8")) as Config;
 
     return config;
 }
@@ -23,7 +25,7 @@ export function createPool(
     selectedJobs: string[],
     stage: string
 ) {
-    let pool: Grader[] = [];
+    const pool: Grader[] = [];
     selectedJobs.forEach((job) => {
         const activeGraders = config[job][stage].filter(
             (grader) => grader.active

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -13,5 +13,3 @@ export interface PostInfo extends BaseInfo {
 export interface JobInfo extends BaseInfo {
     posts: PostInfo[];
 }
-
-// Assign graders

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -13,3 +13,5 @@ export interface PostInfo extends BaseInfo {
 export interface JobInfo extends BaseInfo {
     posts: PostInfo[];
 }
+
+// Assign graders

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import UserError from "./common/UserError";
 import { runPrompt } from "./common/commandUtils";
 import { tests } from "./test-greenhouse";
 import { Command, Argument, Option } from "commander";
-import { green, random } from "colors";
+import { green } from "colors";
 import ora, { Ora } from "ora";
 // @ts-ignore This can be deleted after https://github.com/enquirer/enquirer/issues/135 is fixed.
 import { Select, MultiSelect, Toggle } from "enquirer";

--- a/src/index.ts
+++ b/src/index.ts
@@ -354,7 +354,11 @@ function configureLogoutCommand(command: Command, sso: SSO) {
         });
 }
 
-function configureLoadBalancerCommand(command: Command, sso: SSO) {
+function configureLoadBalancerCommand(
+    command: Command,
+    sso: SSO,
+    spinner: Ora
+) {
     return command
         .command("assign")
         .usage(
@@ -367,7 +371,7 @@ function configureLoadBalancerCommand(command: Command, sso: SSO) {
         )
         .action(async (options) => {
             await provideAuthentication(sso, (page) =>
-                assignGraders(page, options.interactive)
+                assignGraders(spinner, page, options.interactive)
             );
         });
 }
@@ -397,7 +401,11 @@ function configureCommand(command: Command, spinner: Ora) {
     const loginCommand = configureLoginCommand(command, sso);
     const logoutCommand = configureLogoutCommand(command, sso);
     const testingCommand = configureTestingCommand(command, sso, spinner);
-    const loadBalancerCommand = configureLoadBalancerCommand(command, sso);
+    const loadBalancerCommand = configureLoadBalancerCommand(
+        command,
+        sso,
+        spinner
+    );
 
     command.configureHelp({
         visibleCommands: () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,13 +7,13 @@ import { displayError, setupSentry } from "./common/processUtils";
 import UserError from "./common/UserError";
 import { runPrompt } from "./common/commandUtils";
 import { tests } from "./test-greenhouse";
+import assignGraders from "./assign-graders";
 import { Command, Argument, Option } from "commander";
 import { green } from "colors";
 import ora, { Ora } from "ora";
 // @ts-ignore This can be deleted after https://github.com/enquirer/enquirer/issues/135 is fixed.
 import { Select, MultiSelect, Toggle } from "enquirer";
 import { Page } from "puppeteer";
-import assignGraders from "./assign-graders";
 
 async function getJobInteractive(job: Job, message: string, spinner: Ora) {
     spinner.start("Fetching your jobs.");

--- a/yarn.lock
+++ b/yarn.lock
@@ -163,6 +163,11 @@
   dependencies:
     colors "*"
 
+"@types/js-yaml@^4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-4.0.5.tgz#738dd390a6ecc5442f35e7f03fa1431353f7e138"
+  integrity sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==
+
 "@types/jsdom@16.2.14":
   version "16.2.14"
   resolved "https://registry.yarnpkg.com/@types/jsdom/-/jsdom-16.2.14.tgz#26fe9da6a8870715b154bb84cd3b2e53433d8720"


### PR DESCRIPTION
## Done 

Add feature to assign written interviews randomly.

The script scans all written interviews that need graders and, if the default user is assigned to them (the hiring lead is assigned by default), remove it and add 2 random reviewers from a file.


## QA

- Ask me for a file: `ght-graders.yml`
- Put it in your home directory
- `yarn dev assign -i` to run the automation in interactive mode (only mode for now)
- Select jobs
- Check that the command runs 
- Verify in https://canonical.greenhouse.io/people?sort_by=last_activity&sort_order=desc&stage_status_id%5B%5D=2&in_stages%5B%5D=Written+Interview that some graders were assigned

## Issue
Fixes https://github.com/canonical/workplace-engineering-squad/issues/782