### PR TITLE
fix: assign graders to written interviews

### DIFF
--- a/src/assign-graders/LoadBalancer.ts
+++ b/src/assign-graders/LoadBalancer.ts
@@ -1,4 +1,4 @@
-import { Application, Grader } from "./types";
+import { Application, Grader, Job } from "./types";
 import { MAIN_URL } from "../common/constants";
 import UserError from "../common/UserError";
 import { green } from "colors";
@@ -12,14 +12,14 @@ import { Page } from "puppeteer";
 export default class LoadBalancer {
     private page: Page;
     private graders: Grader[];
-    private jobs: string[];
+    private jobs: Job[];
     private spinner: Ora;
     private currentUser: string = "";
 
     constructor(
         page: Page,
         graders: Grader[],
-        selectedJobs: string[],
+        selectedJobs: Job[],
         spinner: Ora
     ) {
         this.page = page;
@@ -32,29 +32,27 @@ export default class LoadBalancer {
      * Return applications in current page
      */
     private async getApplicationsPage() {
-        return await this.page.$$eval(".person", (people) =>
-            people.map((p) => {
-                const applicationID = p.getAttribute("application");
-                const toggleText = p.querySelector(
-                    "a.toggle-interviews"
-                )?.textContent;
-                const toGrade = toggleText?.includes("Scorecard due");
-                const job = p
-                    .querySelector(".job")
-                    // Delete requisition ID next to job name
-                    ?.textContent?.replace(/\(\d+\)$/, "")
-                    .trim();
-                const candidate = p.querySelector(".name a")?.textContent;
+        return await this.page.$$eval(
+            ".person",
+            (people, user) => {
+                return people.map((p) => {
+                    const applicationID = p.getAttribute("application");
+                    const toggleText = p.querySelector(
+                        "a.toggle-interviews"
+                    )?.textContent;
+                    const toGrade = toggleText === `Scorecard due from ${user}`;
+                    const candidate = p.querySelector(".name a")?.textContent;
 
-                if (applicationID && candidate && job && toGrade != null) {
-                    return {
-                        applicationID,
-                        candidate,
-                        job,
-                        toGrade,
-                    };
-                }
-            })
+                    if (applicationID && candidate && toGrade != null) {
+                        return {
+                            applicationID,
+                            candidate,
+                            toGrade,
+                        };
+                    }
+                });
+            },
+            this.currentUser
         );
     }
 
@@ -76,15 +74,15 @@ export default class LoadBalancer {
     /**
      * Find two random graders for an application
      */
-    private findRandomGraders(application: Application) {
+    private findRandomGraders(job: Job) {
         const graders = this.graders.filter(
-            (grader: Grader) => grader.job == application.job
+            (grader: Grader) => grader.jobName == job.jobName
         );
         if (graders.length < 2) {
             throw new UserError("Not enough graders to pick from");
         }
         const grader1 = this.getRandom(graders);
-        // Remove first grader so it doesn't get choosen twice
+        // Remove first grader so it doesn't get chosen twice
         const grader2 = this.getRandom(
             graders.filter((name) => name !== grader1)
         );
@@ -109,7 +107,10 @@ export default class LoadBalancer {
     /**
      * Assign graders to one application
      */
-    private async assignGradersToApplication(application: Application) {
+    private async assignGradersToApplication(
+        application: Application,
+        graders: Grader[]
+    ) {
         this.spinner.start("Processing applications");
 
         const selector = `.person[application="${application?.applicationID}"]`;
@@ -135,40 +136,17 @@ export default class LoadBalancer {
             visible: true,
         });
 
-        // Read graders already assigned
-        const gradersAssigned = await this.page.$$eval(
-            "ul .search-choice span",
-            (el) => el.map((grader) => grader.textContent)
-        );
-        // Skip if already graders assigned
-        if (gradersAssigned.length >= 2) {
-            return;
-        }
-        // Skip if only one grader but it's not the user
-        if (
-            gradersAssigned.length === 1 &&
-            gradersAssigned[0] !== this.currentUser
-        ) {
-            return;
-        }
-
         // Click input field
         await this.page.waitForSelector(".search-field input[type='text']");
         await this.page.click(".search-field input[type='text']");
 
-        // If there's only one grader and is the user running the command remove it
-        // (hiring leads are assigned by default as graders)
-        if (
-            gradersAssigned.length === 1 &&
-            gradersAssigned[0] === this.currentUser
-        ) {
-            await this.page.keyboard.press("Backspace");
-            await this.page.keyboard.press("Backspace");
-        }
+        // Delete current use assigned
+        await this.page.keyboard.press("Backspace");
+        await this.page.keyboard.press("Backspace");
 
-        const [grader1, grader2] = this.findRandomGraders(application);
-        await this.writeGrader(grader1);
-        await this.writeGrader(grader2);
+        // Type graders
+        await this.writeGrader(graders[0]);
+        await this.writeGrader(graders[1]);
 
         // Click save
         await this.page.click("input[type='submit']");
@@ -176,37 +154,52 @@ export default class LoadBalancer {
         this.spinner.stop();
         console.log(
             green("✔"),
-            `Written Interview from ${application.candidate} assigned to: ${grader1.name}, ${grader2.name}`
+            `Written Interview from ${application.candidate} assigned to: ${graders[0].name}, ${graders[1].name}`
         );
     }
 
+    /**
+     * Return url for the page that shows written interviews for a given job
+     */
+    private buildUrl(job: Job) {
+        const url = new URL(`${MAIN_URL}people`);
+        url.searchParams.append("stage_status_id", "2");
+        url.searchParams.append("in_stages", "Written Interview");
+        url.searchParams.append("hiring_plan_id", job.id.toString());
+
+        return url.href;
+    }
+
     public async execute(): Promise<void> {
-        await this.page.goto(
-            `${MAIN_URL}people?sort_by=last_activity&sort_order=desc&stage_status_id%5B%5D=2&in_stages%5B%5D=Written+Interview`
-        );
-        await this.findUsername();
-
-        while (true) {
+        for (const job of this.jobs) {
+            const url = this.buildUrl(job);
+            await this.page.goto(url);
             await this.page.waitForSelector(".person");
-            const applicationsPage = await this.getApplicationsPage();
-            for (const application of applicationsPage) {
-                if (
-                    application &&
-                    application?.toGrade &&
-                    this.jobs.includes(application.job)
-                ) {
-                    await this.assignGradersToApplication(application);
+
+            await this.findUsername();
+            while (true) {
+                const applicationsPage = await this.getApplicationsPage();
+                for (const application of applicationsPage) {
+                    if (application && application.toGrade) {
+                        const graders = this.findRandomGraders(job);
+                        await this.assignGradersToApplication(
+                            application,
+                            graders
+                        );
+                    }
                 }
+
+                // Keep doing this until there are no more pages
+                const nextPageBtn = await this.page.$(
+                    "a.next_page:not(.disabled)"
+                );
+                if (!nextPageBtn) break;
+
+                await Promise.all([
+                    this.page.waitForNavigation(),
+                    nextPageBtn.click(),
+                ]);
             }
-
-            // Keep doing this until there are no more pages
-            const nextPageBtn = await this.page.$("a.next_page:not(.disabled)");
-            if (!nextPageBtn) break;
-
-            await Promise.all([
-                this.page.waitForNavigation(),
-                nextPageBtn.click(),
-            ]);
         }
     }
 }

--- a/src/assign-graders/LoadBalancer.ts
+++ b/src/assign-graders/LoadBalancer.ts
@@ -69,6 +69,17 @@ export default class LoadBalancer {
     private async writeGrader(grader: Grader) {
         await this.page.type(".search-field input[type='text']", grader.name);
         await this.page.keyboard.press("Enter");
+
+        // Make sure that the user was correctly assigned
+        const gradersAssigned = await this.page.$$eval(
+            "ul .search-choice span",
+            (el) => el.map((grader) => grader.textContent)
+        );
+        if (!gradersAssigned.includes(grader.name)) {
+            throw new UserError(
+                `Couldn't assign ${grader.name}. Please verify there's a Greenhouse user with this name`
+            );
+        }
     }
 
     /**

--- a/src/assign-graders/types.ts
+++ b/src/assign-graders/types.ts
@@ -11,12 +11,16 @@ export type Config = {
 
 export type Grader = {
     name: string;
-    job: string;
+    jobName: string;
 };
 
 export type Application = {
     candidate: string;
-    job: string;
     applicationID: string;
     toGrade: boolean;
+};
+
+export type Job = {
+    id: number;
+    jobName: string;
 };

--- a/src/assign-graders/utils.ts
+++ b/src/assign-graders/utils.ts
@@ -1,4 +1,4 @@
-import { Config, Grader } from "./types";
+import { Config, Grader, Job } from "./types";
 import yaml from "js-yaml";
 import fs from "fs";
 import { homedir } from "os";
@@ -20,18 +20,14 @@ export function loadConfig(): Config {
 /**
  * Return list of graders based on selected options
  */
-export function createPool(
-    config: Config,
-    selectedJobs: string[],
-    stage: string
-) {
+export function createPool(config: Config, selectedJobs: Job[], stage: string) {
     const pool: Grader[] = [];
-    selectedJobs.forEach((job) => {
-        const activeGraders = config[job][stage].filter(
+    selectedJobs.forEach(({ jobName }) => {
+        const activeGraders = config[jobName][stage].filter(
             (grader) => grader.active
         );
         activeGraders.forEach(({ name }) => {
-            pool.push({ name, job });
+            pool.push({ name, jobName });
         });
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -363,9 +363,12 @@ function configureLoadBalancerCommand(
         .command("assign")
         .usage(
             "([-i | --interactive])" +
-                "\n\n Examples: \n\t ght assign --interactive "
+                "\n\n Examples: \n\t ght assign --interactive"
         )
-        .description("Assign random graders to written interview")
+        .description(
+            "Assign graders to written interviews for the jobs selected.\n" +
+                "Graders are randomly picked from a ght-graders.yml file defined in your home directory"
+        )
         .addOption(
             new Option("-i, --interactive", "Enable interactive interface")
         )


### PR DESCRIPTION
## Done 

- Fix written interview "load balancer" behaviour by going to different pages depending on the job

## QA 
- Make sure you have a `ght-graders.yml` file in your home directory
- `yarn dev assing -i`
- Select the jobs you want to assign graders to
- Let the automation do its work (it will find the written interviews assigned to you alone and will assigned two random graders from the list in the config file)
- Check logs in the console and verify that the same action was performed in Greenhouse

## Issue
Fixes #150 