### PR TITLE
Only grade when a single interview is present on a written interview

### DIFF
--- a/src/assign-graders/LoadBalancer.ts
+++ b/src/assign-graders/LoadBalancer.ts
@@ -123,12 +123,26 @@ export default class LoadBalancer {
         graders: Grader[]
     ) {
         const selector = `.person[application="${application?.applicationID}"]`;
+        let interviewCount = 0;
 
         // Click toggle button
         await this.page.waitForSelector(`${selector} .toggle-interviews`);
         await this.page.$eval(`${selector} .toggle-interviews`, (toggle) =>
             (toggle as HTMLAnchorElement).click()
         );
+
+        // Check there is only one interviewer
+        await this.page.waitForSelector(`${selector} tr.interview`);
+        interviewCount = await this.page.$$eval(
+            `${selector} tr.interview`,
+            (interviewRows) => {
+                return interviewRows.length;
+            }
+        );
+
+        if (interviewCount !== 1) {
+            return;
+        }
 
         // Click edit
         await this.page.waitForSelector(

--- a/src/automations/SSO.ts
+++ b/src/automations/SSO.ts
@@ -196,6 +196,7 @@ export default class SSO {
         const loginCookies = await this.login();
         this.spinner.start("Setting up...");
         const browser = await Puppeteer.launch({
+            headless: true,
             args: ["--no-sandbox"],
         });
         const page = await browser.newPage();


### PR DESCRIPTION
## Done
- When assigning the graders for the wirrten interview check if there is only one interview already set
- Set the headless atr to true so its easier to find and change in the future

## QA
- Goulin!!!
