### PR TITLE
Set the default viewport to null

### DIFF
--- a/src/automations/SSO.ts
+++ b/src/automations/SSO.ts
@@ -197,6 +197,7 @@ export default class SSO {
         this.spinner.start("Setting up...");
         const browser = await Puppeteer.launch({
             headless: true,
+	    defaultViewport: null,
             args: ["--no-sandbox"],
         });
         const page = await browser.newPage();


### PR DESCRIPTION
## Done
Set the default viewport to null so it's responsible

## QA
- Run `yarn install`
- Update the `SSO.ts` file to have `headless: false`
- Run `yarn dev assign -i`
- Check the browser appears and is responsive not defaulting to 600x800. 