### PR TITLE
Add the ability to select the number of graders when assigning

### DIFF
--- a/src/assign-graders/LoadBalancer.ts
+++ b/src/assign-graders/LoadBalancer.ts
@@ -15,17 +15,20 @@ export default class LoadBalancer {
     private jobs: Job[];
     private spinner: Ora;
     private currentUser = "";
+    private gradersCount = 2;
 
     constructor(
         page: Page,
         graders: Grader[],
         selectedJobs: Job[],
-        spinner: Ora
+        spinner: Ora,
+        gradersCount: number
     ) {
         this.page = page;
         this.graders = graders;
         this.jobs = selectedJobs;
         this.spinner = spinner;
+        this.gradersCount = gradersCount;
     }
 
     /**
@@ -57,13 +60,6 @@ export default class LoadBalancer {
     }
 
     /**
-     * Get random grader from array
-     */
-    private getRandom(graders: Grader[]) {
-        return graders[Math.floor(Math.random() * graders.length)];
-    }
-
-    /**
      * Type grader's name
      */
     private async writeGrader(grader: Grader) {
@@ -89,16 +85,17 @@ export default class LoadBalancer {
         const graders = this.graders.filter(
             (grader: Grader) => grader.jobName == job.jobName
         );
-        if (graders.length < 2) {
+        if (graders.length < this.gradersCount) {
             throw new UserError("Not enough graders to pick from");
         }
-        const grader1 = this.getRandom(graders);
-        // Remove first grader so it doesn't get chosen twice
-        const grader2 = this.getRandom(
-            graders.filter((name) => name !== grader1)
-        );
 
-        return [grader1, grader2];
+        // Shuffle graders array
+        const shuffledGraders = graders.sort(() => 0.5 - Math.random());
+
+        // Get sub-array of first elements to the graders count selected
+        const selectedGraders = shuffledGraders.slice(0, this.gradersCount);
+
+        return selectedGraders;
     }
 
     /**
@@ -167,18 +164,21 @@ export default class LoadBalancer {
         await this.page.keyboard.press("Backspace");
         await this.page.keyboard.press("Backspace");
 
+        let outputMessage = `Written Interview from ${application.candidate} assigned to: `;
+
         // Type graders
-        await this.writeGrader(graders[0]);
-        await this.writeGrader(graders[1]);
+        let comma = "";
+        for (const grader of graders) {
+            await this.writeGrader(grader);
+            outputMessage += `${comma}${grader.name}`;
+            comma = ", ";
+        }
 
         // Click save
         await this.page.click("input[type='submit']");
 
         this.spinner.stop();
-        console.log(
-            green("✔"),
-            `Written Interview from ${application.candidate} assigned to: ${graders[0].name}, ${graders[1].name}`
-        );
+        console.log(green("✔"), outputMessage);
         this.spinner.start();
     }
 

--- a/src/assign-graders/index.ts
+++ b/src/assign-graders/index.ts
@@ -3,7 +3,7 @@ import { loadConfig, createPool } from "./utils";
 import UserError from "../common/UserError";
 import { runPrompt } from "../common/commandUtils";
 // @ts-ignore This can be deleted after https://github.com/enquirer/enquirer/issues/135 is fixed.
-import { MultiSelect } from "enquirer";
+import { MultiSelect, Select } from "enquirer";
 import Puppeteer from "puppeteer";
 import { Ora } from "ora";
 import Job from "../automations/Job";
@@ -22,6 +22,15 @@ export default async function assignGraders(
     const job = new Job(page, spinner);
     const jobs = await job.getJobs();
     if (!jobs.size) throw new UserError("You don't have any job.");
+
+    const graderCountPrompt = new Select({
+        name: "Graders",
+        message: "Choose the number of graders",
+        choices: ["1", "2", "3", "4"],
+        initial: 1,
+    });
+    const gradersCountResponse: string[] = await runPrompt(graderCountPrompt);
+    const gradersCount: number = +gradersCountResponse;
 
     const prompt = new MultiSelect({
         name: "Jobs",
@@ -55,6 +64,12 @@ export default async function assignGraders(
         );
     }
 
-    const loadBalancer = new LoadBalancer(page, graders, selectedJobs, spinner);
+    const loadBalancer = new LoadBalancer(
+        page,
+        graders,
+        selectedJobs,
+        spinner,
+        gradersCount
+    );
     await loadBalancer.execute();
 }

--- a/src/automations/SSO.ts
+++ b/src/automations/SSO.ts
@@ -197,7 +197,7 @@ export default class SSO {
         this.spinner.start("Setting up...");
         const browser = await Puppeteer.launch({
             headless: true,
-	    defaultViewport: null,
+            defaultViewport: null,
             args: ["--no-sandbox"],
         });
         const page = await browser.newPage();


### PR DESCRIPTION
## Done
Added an option to the `assign` function which asks how many graders you would like to assign.

## QA
1. Pull this branch
2. Run `yarn dev assign -i`
3. See that you are asked how many graders you would like to assign
4. Select a job (maybe I can show you on a quick call if you don't have access)
5. See that the selected number of graders is respected when allocating graders

Fixes https://github.com/canonical/ght/issues/175