### PR TITLE
build(pkg): add support for arm64

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,8 +7,16 @@ env:
 
 jobs:
     tests:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         steps:
-            - uses: actions/checkout@v2
+            - name: Checkout repository
+              uses: actions/checkout@v3
+            - name: Setup NodeJS
+              run: |
+                sudo snap install node --channel=16/stable --classic
+                npm install -g typescript
+                npm install -g ts-node
+            - name: Install project dependencies
+              run: yarn
             - name: Run ght tests
               run: yarn dev doctor

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,11 +5,15 @@ description: An automated browser that does a set of tasks on Canonical's Greenh
 base: core20
 confinement: strict
 grade: stable
-architectures: [amd64]
+architectures:
+    - amd64
+    - arm64
 parts:
     node:
         plugin: dump
-        source: https://nodejs.org/dist/v16.14.0/node-v16.14.0-linux-x64.tar.xz
+        source: 
+            - on amd64: https://nodejs.org/dist/v16.14.0/node-v16.14.0-linux-x64.tar.xz
+            - on arm64: https://nodejs.org/dist/v16.14.0/node-v16.14.0-linux-arm64.tar.xz
         stage:
             - bin
             - include
@@ -18,13 +22,15 @@ parts:
         after: [node]
         plugin: nil
         source: .
+        build-packages:
+            - on arm64: ["chromium-browser"]
         override-build: |
             npm config set unsafe-perm true
             npm install -g yarn
             yarn install
             yarn build
             # this causes PROT_EXEC problem
-            rm ./node_modules/puppeteer/.local-chromium/linux-*/chrome-linux/nacl_irt_*.nexe
+            rm -f ./node_modules/puppeteer/.local-chromium/linux-*/chrome-linux/nacl_irt_*.nexe
             cp -a ./dist/. $SNAPCRAFT_PART_INSTALL/
             cp -r ./node_modules $SNAPCRAFT_PART_INSTALL
         stage-packages:


### PR DESCRIPTION
This should enable support for arm64 devices - this came up today with somebody running Ubuntu on an M1 Mac.

The build succeeds using `snapcraft remote-build`, and I've attached that artefact for testing purposes! It can be installed with:

```
sudo snap install --dangerous ./ght_1.3.1_multi.snap
```

Download here if interested: https://wormhole.app/r0xel#rAmjMtPyyGTIrf_whVfgcw