### PR TITLE
Strip mark up from the innerHTML from alljobs

### DIFF
--- a/src/automations/Job.ts
+++ b/src/automations/Job.ts
@@ -251,8 +251,11 @@ export default class Job {
         await this.page.goto(url);
 
         const body = await this.page.$("body");
-        const innerHTML = await body?.evaluate((element) => element.innerHTML);
+        let innerHTML = await body?.evaluate((element) => element.innerHTML);
         if (!innerHTML) throw new Error(`Jobs cannot be found from ${url}`);
+
+        // Strip HTML markup around the JSON. For example: <pre>
+        innerHTML = innerHTML.replace(/(<([^>]+)>)/gi, "");
 
         const content = JSON.parse(decodeURIComponent(innerHTML));
 


### PR DESCRIPTION
## Done
Added a small parsing to the innerHTML of the Alljobs feed to strip the `<pre>` tag from around it.

## QA
- Run `ght assign -i` locally and see that it fails for this error: "Unexpected token < in JSON at position 0"
- Pull this branch
- Run `yarn dev assign -i`
- See that you get through to the questions.
