### PR TITLE
Move the greenhouse config location to ~/.config

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Running `ght assign -i` will guide you through the process of selecting the jobs
 
 ### Authentication
 
-The CLI will manage authentication. To avoid entering credentials every time the command runs, the authorization cookie created by Greenhouse and SSO will be stored in the file: `~/.canonical-greenhouse.json`.
+The CLI will manage authentication. To avoid entering credentials every time the command runs, the authorization cookie created by Greenhouse and SSO will be stored in the file: `~/.config/ght/.canonical-greenhouse.json`.
 
 Every time the authentication requires a refresh, you will be requested to authenticate.
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ght
-version: "1.5.1"
+version: "1.5.2"
 summary: Perform actions in Canonical's Greenhouse automatically.
 description: An automated browser that does a set of tasks on Canonical's Greenhouse dashboard without the need of interaction with the UI.
 base: core20

--- a/src/auth/UbuntuSSO.ts
+++ b/src/auth/UbuntuSSO.ts
@@ -9,7 +9,8 @@ import Enquirer = require("enquirer");
 import Puppeteer from "puppeteer";
 import { Ora } from "ora";
 import { CookieJar } from "tough-cookie";
-import { existsSync, writeFileSync } from "fs";
+import { existsSync, writeFileSync, mkdirSync } from "fs";
+import { dirname } from "path";
 
 export default class UbuntuSSO extends Authentication {
     private httpsAgent;
@@ -66,6 +67,10 @@ export default class UbuntuSSO extends Authentication {
     }
 
     private saveUserSettings() {
+        const confDir = dirname(this.config.userSettingsPath);
+        if (!existsSync(confDir)) {
+            mkdirSync(confDir, { recursive: true });
+        }
         writeFileSync(this.config.userSettingsPath, JSON.stringify(this.jar));
     }
 

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -86,8 +86,8 @@ class Config {
         return join(
             homedir(),
             this.isCanonical()
-                ? ".canonical-greenhouse.json"
-                : ".ght-greenhouse.json"
+                ? ".config/ght/.canonical-greenhouse.json"
+                : ".config/ght/.ght-greenhouse.json"
         );
     }
 


### PR DESCRIPTION
## Done

- Took @jnsgruk [patch](https://github.com/jnsgruk/nixos-config/blob/main/pkgs/ght/config-location.patch) to move the config file to `~/.config/ght` to be a good citizen. Instead of the home dir.

## QA

- Run `yarn dev assign -i`
- Log in and check the command works
- Exit ght
- Run `cat ~/.config/ght/.canonical-greenhouse.json` and see the config exists there now.