### PR TITLE
Assign multiple hold stage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ght",
-    "version": "1.5.1",
+    "version": "1.5.3",
     "scripts": {
         "build": "tsc && cp package.json ght ./dist",
         "dev": "NODE_ENV=development ts-node ./src/index.ts",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ght
-version: "1.5.2"
+version: "1.5.3"
 summary: Perform actions in Canonical's Greenhouse automatically.
 description: An automated browser that does a set of tasks on Canonical's Greenhouse dashboard without the need of interaction with the UI.
 base: core20

--- a/src/core/LoadBalancer.ts
+++ b/src/core/LoadBalancer.ts
@@ -147,13 +147,20 @@ export default class LoadBalancer {
         );
 
         // Wait for modal to open
-        await this.page.waitForSelector("ul.chzn-choices", {
+        await this.page.waitForSelector(".modal-dialog", {
             visible: true,
         });
-
-        // Click input field
-        await this.page.waitForSelector(".search-field input[type='text']");
-        await this.page.click(".search-field input[type='text']");
+        // Double check the graders input is visible
+        await this.page.waitForSelector(
+            "#edit_take_home_test_graders_modal .search-field input",
+            {
+                visible: true,
+            }
+        );
+        // Click the graders input
+        await this.page.click(
+            "#edit_take_home_test_graders_modal .search-field input"
+        );
 
         // Delete current use assigned
         await this.page.keyboard.press("Backspace");
@@ -171,7 +178,8 @@ export default class LoadBalancer {
         }
 
         // Click save
-        await this.page.click("input[type='submit']");
+        await this.page.waitForSelector("input[type='submit']#save_graders");
+        await this.page.click("input[type='submit']#save_graders");
         this.allocationsCount++;
 
         this.spinner.stop();


### PR DESCRIPTION
## Done

Allow assignment of multiple interviews without crashing due to a race condition.

## QA
1. Pull down this code
2. Run it (`yarn dev assign -i`) against the Hold stage in a test job with multiple candidates awaiting the assignment of their written interview (assignment is conditioned on you being the sole grader of the WI)
3. Check that it sets the right amount of graders and does not fail after the first one.

Fixes https://warthogs.atlassian.net/browse/WD-5947
Fixes https://github.com/canonical/ght/issues/203