### PR TITLE
WD-6445 - Fix a reload and browser stop race condition

### DIFF
--- a/src/core/LoadBalancer.ts
+++ b/src/core/LoadBalancer.ts
@@ -182,7 +182,7 @@ export default class LoadBalancer {
         console.log(green("✔"), outputMessage);
         this.spinner.start();
 
-        this.page.reload();
+        await this.page.reload();
     }
 
     /**


### PR DESCRIPTION
## Done

Await the page reload to ensure the `browser.close()` is not triggered while the network is not idle.

Fixes https://warthogs.atlassian.net/browse/WD-6445 