### PR TITLE
show prompt to delete job posts in unrecognized regions

### DIFF
--- a/src/__tests__/Job.test.ts
+++ b/src/__tests__/Job.test.ts
@@ -441,7 +441,7 @@ describe("Job tests", () => {
             jobData = { id: 1, name: "test", posts: [postInfo] };
             const job = new Job(page, spinner, config);
 
-            await job.deletePosts(config, jobData);
+            await job.deletePosts(jobData);
 
             expect(spinner.text).toEqual("1 of 1 job posts were deleted.");
             expect(spinner.succeed).toHaveBeenCalledTimes(1);
@@ -451,7 +451,7 @@ describe("Job tests", () => {
             const job = new Job(page, spinner, config);
 
             await expect(
-                job.deletePosts(config, jobData, ["test"], 1)
+                job.deletePosts(jobData, ["test"], 1)
             ).rejects.toThrow();
         });
 
@@ -459,7 +459,7 @@ describe("Job tests", () => {
             const job = new Job(page, spinner, config);
 
             try {
-                await job.deletePosts(config, jobData, ["Apac"], 1);
+                await job.deletePosts(jobData, ["Apac"], 1);
             } catch (error) {
                 expect(error).toEqual(
                     TypeError(

--- a/src/__tests__/Job.test.ts
+++ b/src/__tests__/Job.test.ts
@@ -458,15 +458,9 @@ describe("Job tests", () => {
         it("fails if region is misspelled/given uppercase character", async () => {
             const job = new Job(page, spinner, config);
 
-            try {
-                await job.deletePosts(jobData, ["Apac"], 1);
-            } catch (error) {
-                expect(error).toEqual(
-                    TypeError(
-                        "Cannot read properties of undefined (reading 'filter')"
-                    )
-                );
-            }
+            await expect(
+                job.deletePosts(jobData, ["Apac"], 1)
+            ).rejects.toThrow(TypeError);
         });
     });
 

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -99,6 +99,13 @@ class Config {
     }
 
     /**
+     * List of all locations
+     */
+    get locations(): string[] {
+        return Object.values(this.regions).flat();
+    }
+
+    /**
      * Authorization URL
      */
     get loginUrl(): string {

--- a/src/controllers/ReplicateController.ts
+++ b/src/controllers/ReplicateController.ts
@@ -65,7 +65,6 @@ export class ReplicateController extends BaseController {
             );
 
             await deletePostsInteractive(
-                this.config,
                 job,
                 jobInfo,
                 regionNames,

--- a/src/controllers/RepostController.ts
+++ b/src/controllers/RepostController.ts
@@ -116,8 +116,7 @@ export class RepostController extends BaseController {
         page: Puppeteer.Page
     ): Promise<JobPost> {
         const jobPost = new JobPost(page, this.config);
-        // Remove brackets from the location name
-        const postLocation = postInfo.location.replace(/^\(|\)$/g, "");
+        const postLocation = postInfo.location
         // Duplicate job post in the same location
         await jobPost.duplicate(postInfo, postLocation, boardToPost);
         // Mark all newly added job posts as live

--- a/src/controllers/RepostController.ts
+++ b/src/controllers/RepostController.ts
@@ -2,10 +2,8 @@ import { BaseController } from "./BaseController";
 import Job from "../core/Job";
 import JobPost from "../core/JobPost";
 import { JobBoard, JobInfo, PostInfo } from "../core/types";
-import Config from "../config/Config";
 import { UserError } from "../utils/processUtils";
 import { getJobInteractive } from "../utils/prompts";
-import { joinURL } from "../utils/pageUtils";
 import { runPrompt } from "../utils/commandUtils";
 import { Command } from "commander";
 import { green } from "colors";
@@ -67,7 +65,6 @@ export class RepostController extends BaseController {
                 page
             );
             const deletePost = await this.deletePostInteractive(
-                this.config,
                 jobPost,
                 jobInfo,
                 postInfo
@@ -100,11 +97,7 @@ export class RepostController extends BaseController {
                 boardToPost,
                 page
             );
-            const referrer = joinURL(
-                this.config.greenhouseUrl,
-                `/plans/${jobInfo.id}/jobapp`
-            );
-            await jobPost.deletePost(postInfo, referrer);
+            await jobPost.deletePost(postInfo, jobInfo);
             await page.reload();
             console.log(green("✔"), "Old job post deleted.");
         }
@@ -164,7 +157,6 @@ export class RepostController extends BaseController {
     }
 
     private async deletePostInteractive(
-        config: Config,
         jobPost: JobPost,
         jobInfo: JobInfo,
         postInfo: PostInfo
@@ -178,11 +170,7 @@ export class RepostController extends BaseController {
 
         const shouldDelete = await runPrompt(prompt);
         if (!shouldDelete) return false;
-        const referrer = joinURL(
-            config.greenhouseUrl,
-            `/plans/${jobInfo.id}/jobapp`
-        );
-        await jobPost.deletePost(postInfo, referrer);
+        await jobPost.deletePost(postInfo, jobInfo);
         return true;
     }
 }

--- a/src/controllers/ResetController.ts
+++ b/src/controllers/ResetController.ts
@@ -68,7 +68,7 @@ export class ResetController extends BaseController {
             jobInfo = await job.getJobData(jobID);
             this.spinner.succeed();
         }
-        await job.deletePosts(this.config, jobInfo, regionNames, postID);
+        await job.deletePosts(jobInfo, regionNames, postID);
 
         console.log("Happy hiring!");
 

--- a/src/core/Job.ts
+++ b/src/core/Job.ts
@@ -10,6 +10,9 @@ import { evaluate, isDevelopment } from "../utils/processUtils";
 import Config from "../config/Config";
 import Puppeteer from "puppeteer";
 import { Ora } from "ora";
+// @ts-ignore 2023-11-24: https://github.com/enquirer/enquirer/issues/135 still not solved.
+import { Toggle } from "enquirer";
+import { runPrompt } from "../utils/commandUtils";
 
 const RECRUITER_TAG = "RECRUITER";
 
@@ -144,8 +147,11 @@ export default class Job {
                 );
             }
         }
-
+        
         const postToDelete = [];
+        // Posts whose region is not part of those we define
+        const postsUnknownRegion = []
+
         for (const post of posts) {
             const isProtected = !!this.config.protectedBoards.find(
                 (protectedBoardName) =>
@@ -154,6 +160,7 @@ export default class Job {
                     )
             );
 
+            // Job post is on the entered regions
             const locationCheck =
                 !enteredRegions ||
                 !!enteredRegions.find((enteredRegion) => {
@@ -166,15 +173,26 @@ export default class Job {
                     return filteredLocations.length > 0;
                 });
 
+            // Job post region is not in our list
+            const isRegionUnknown = !this.config.regionNames.find((location) => {
+                return post.location.match(new RegExp(location, "i"))
+            });                
+
             const nameCheck = !similarPost || similarPost.name === post.name;
-            if (!isProtected && locationCheck && nameCheck)
-                postToDelete.push(post);
+            if (!isProtected && nameCheck) {
+                if (locationCheck) {
+                    postToDelete.push(post);
+                } else if (isRegionUnknown) {
+                    postsUnknownRegion.push(post)
+                }
+            }
+                
+            
         }
-        return postToDelete;
+        return [postToDelete, postsUnknownRegion];
     }
 
     public async deletePosts(
-        config: Config,
         jobData: JobInfo,
         enteredRegions?: string[],
         similarPostID?: number
@@ -182,26 +200,40 @@ export default class Job {
         this.spinner.start(`Starting to delete job posts.`);
         const posts: PostInfo[] = jobData.posts;
 
-        const postToDelete = this.filterPostsToDelete(
+        const [postToDelete, postsUnknownRegion] = this.filterPostsToDelete(
             posts,
             similarPostID,
             enteredRegions
         );
 
-        // We need some ids to be able to delete posts.
-        // They are the same for all boards.
+        // We need `publishStatusId` and `unpublishStatusId`
+        // to be able to delete posts. They are the same for all boards.
         const boardToPost = await this.getBoardToPost();
 
-        const referrer = joinURL(
-            config.greenhouseUrl,
-            `/plans/${jobData.id}/jobapp`
-        );
+        await this.deleteJobPosts(postToDelete, boardToPost, jobData);
+        
+        // Check if there are posts on unrecognised regions and prompt to delete them
+        if (postsUnknownRegion.length > 0) {
+            const prompt = new Toggle({
+                message: `${postsUnknownRegion.length} job posts on unrecognised regions. Do you want to delete them?`,
+                enabled: "Yes",
+                disabled: "No",
+                initial: false,
+            });
+            const confirm = await runPrompt(prompt);
+            if (confirm) {
+                await this.deleteJobPosts(postsUnknownRegion, boardToPost, jobData);
+            }
+        }
+    }
+
+    private async deleteJobPosts(postsToDelete: PostInfo[], boardToPost: JobBoard, jobData: JobInfo) {
         let count = 1;
-        const totalJobsToDelete = postToDelete.length;
-        for (const post of postToDelete) {
+        const totalJobsToDelete = postsToDelete.length;
+        for (const post of postsToDelete) {
             post.isLive &&
                 (await this.jobPost.setStatus(post, "offline", boardToPost));
-            await this.jobPost.deletePost(post, referrer);
+            await this.jobPost.deletePost(post, jobData);
             await this.page.reload();
 
             this.spinner.text = `${count} of ${totalJobsToDelete} job posts were deleted.`;

--- a/src/core/Job.ts
+++ b/src/core/Job.ts
@@ -159,36 +159,28 @@ export default class Job {
                         new RegExp(post.boardInfo.name, "i")
                     )
             );
+            const nameCheck = !similarPost || similarPost.name === post.name;
 
             // Job post is on the entered regions
             const locationCheck =
                 !enteredRegions ||
                 !!enteredRegions.find((enteredRegion) => {
-                    const filteredLocations = this.config.regions[
+                    return this.config.regions[
                         enteredRegion
-                    ].filter((location) =>
-                        post.location.match(new RegExp(location, "i"))
-                    );
-
-                    return filteredLocations.length > 0;
+                    ].includes(post.location)
                 });
-
             // Job post region is not in our list
-            const isRegionUnknown = !this.config.regionNames.find((location) => {
-                return post.location.match(new RegExp(location, "i"))
-            });                
+            const isUnknownRegion = !this.config.locations.includes(post.location);
 
-            const nameCheck = !similarPost || similarPost.name === post.name;
             if (!isProtected && nameCheck) {
                 if (locationCheck) {
                     postToDelete.push(post);
-                } else if (isRegionUnknown) {
+                } else if (isUnknownRegion) {
                     postsUnknownRegion.push(post)
                 }
             }
-                
-            
         }
+
         return [postToDelete, postsUnknownRegion];
     }
 
@@ -214,8 +206,12 @@ export default class Job {
         
         // Check if there are posts in unrecognised regions and prompt to delete them
         if (postsUnknownRegion.length > 0) {
+            console.log(`${postsUnknownRegion.length} job posts in unrecognised regions:`)
+            for (const post of postsUnknownRegion) {
+                console.log(`${this.config.greenhouseUrl}/jobapps/${post.id}/edit in ${post.location}`)
+            }
             const prompt = new Toggle({
-                message: `${postsUnknownRegion.length} job posts in unrecognised regions. Do you want to delete them?`,
+                message: "Do you want to delete them?",
                 enabled: "Yes",
                 disabled: "No",
                 initial: false,

--- a/src/core/Job.ts
+++ b/src/core/Job.ts
@@ -212,10 +212,10 @@ export default class Job {
 
         await this.deleteJobPosts(postToDelete, boardToPost, jobData);
         
-        // Check if there are posts on unrecognised regions and prompt to delete them
+        // Check if there are posts in unrecognised regions and prompt to delete them
         if (postsUnknownRegion.length > 0) {
             const prompt = new Toggle({
-                message: `${postsUnknownRegion.length} job posts on unrecognised regions. Do you want to delete them?`,
+                message: `${postsUnknownRegion.length} job posts in unrecognised regions. Do you want to delete them?`,
                 enabled: "Yes",
                 disabled: "No",
                 initial: false,

--- a/src/core/Job.ts
+++ b/src/core/Job.ts
@@ -206,9 +206,9 @@ export default class Job {
         
         // Check if there are posts in unrecognised regions and prompt to delete them
         if (postsUnknownRegion.length > 0) {
-            console.log(`${postsUnknownRegion.length} job posts in unrecognised regions:`)
+            this.spinner.warn(`${postsUnknownRegion.length} job posts in unrecognised regions:`)
             for (const post of postsUnknownRegion) {
-                console.log(`${this.config.greenhouseUrl}/jobapps/${post.id}/edit in ${post.location}`)
+                console.log(`- ${post.location}`)
             }
             const prompt = new Toggle({
                 message: "Do you want to delete them?",

--- a/src/core/Job.ts
+++ b/src/core/Job.ts
@@ -224,6 +224,7 @@ export default class Job {
     }
 
     private async deleteJobPosts(postsToDelete: PostInfo[], boardToPost: JobBoard, jobData: JobInfo) {
+        this.spinner.start();
         let count = 1;
         const totalJobsToDelete = postsToDelete.length;
         for (const post of postsToDelete) {

--- a/src/core/JobPost.ts
+++ b/src/core/JobPost.ts
@@ -1,4 +1,4 @@
-import { JobBoard, PostInfo } from "./types";
+import { JobBoard, JobInfo, PostInfo } from "./types";
 import { usaCities } from "../config/defaults";
 import {
     getCSRFToken,
@@ -69,10 +69,14 @@ export default class JobPost {
     public isSuccessful = (response: { [key: string]: string }) =>
         !!(response?.status === "success" || response?.success);
 
-    public async deletePost(jobPost: PostInfo, referrer: string) {
+    public async deletePost(jobPost: PostInfo, jobData: JobInfo) {
         const url = joinURL(
             this.config.greenhouseUrl,
             `/jobapps/${jobPost.id}`
+        );
+        const referrer = joinURL(
+            this.config.greenhouseUrl,
+            `/plans/${jobData.id}/jobapp`
         );
 
         await sendRequest(

--- a/src/core/JobPost.ts
+++ b/src/core/JobPost.ts
@@ -57,7 +57,8 @@ export default class JobPost {
         return {
             id: parseInt(jobPostID),
             name: titleLocationInfo[0],
-            location: titleLocationInfo[1],
+            // Remove surrounding parentheses
+            location: titleLocationInfo[1].replace(/\(|\)/g, ''),
             boardInfo: {
                 name: boardName,
                 id: boardID,

--- a/src/utils/prompts.ts
+++ b/src/utils/prompts.ts
@@ -85,7 +85,6 @@ export async function getRegionsInteractive(
 }
 
 export async function deletePostsInteractive(
-    config: Config,
     job: Job,
     jobInfo: JobInfo,
     regionNames: string[],

--- a/src/utils/prompts.ts
+++ b/src/utils/prompts.ts
@@ -100,6 +100,6 @@ export async function deletePostsInteractive(
 
     const shouldDelete = await runPrompt(prompt);
     if (shouldDelete) {
-        await job.deletePosts(config, jobInfo, regionNames, similar);
+        await job.deletePosts(jobInfo, regionNames, similar);
     }
 }


### PR DESCRIPTION
## Done

Add a last check so, after deleting job posts from the regions selected by the user, prompt to delete job posts for locations that are not in the our list ("unrecognised").

GIVEN a job post is published in:

1. Riga, Latvia
2. Vancouver, Canada
3. City-not-in-our-list

WHEN running
```
ght reset <id> -r emea
```
THEN ght will
1. Remove job post in Riga (emea)
2. Ask if you want to remove 1 remaining job post in unrecognised region
3. If Yes, remove job post in "City-not-in-our-list"

## QA

- Find a job post on a demo job
- Create a few copies with the replicate command
```
yarn dev replicate <job_post_id> #you can cancel after a few are created
```
- In Greenhouse, modify the region of a couple of them to something random
- Run reset
```
yarn dev reset <job_post_id>
```
- Verify that you are asked whether you want to delete them

(you may want to repeat the process in interactive mode (`-i`)

## Issue
https://warthogs.atlassian.net/browse/WD-7418