### PR TITLE
snap: fix arm64 build of ght

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -2,18 +2,18 @@ name: ght
 version: "1.6.0"
 summary: Perform actions in Canonical's Greenhouse automatically.
 description: An automated browser that does a set of tasks on Canonical's Greenhouse dashboard without the need of interaction with the UI.
-base: core20
+base: core22
 confinement: strict
 grade: stable
 architectures:
-    - amd64
-    - arm64
+    - build-on: amd64
+    - build-on: arm64
 parts:
     node:
         plugin: dump
         source:
             - on amd64: https://nodejs.org/dist/v20.11.0/node-v20.11.0-linux-x64.tar.gz
-            - on arm64: https://nodejs.org/dist/v20.11.0/node-v20.11.0-linux-x64.tar.xz
+            - on arm64: https://nodejs.org/dist/v20.11.0/node-v20.11.0-linux-arm64.tar.gz
         stage:
             - bin
             - include
@@ -22,8 +22,11 @@ parts:
         after: [node]
         plugin: nil
         source: .
-        build-packages:
-            - on arm64: ["chromium-browser"]
+        build-snaps:
+            - chromium
+        build-environment:
+            - PUPPETEER_SKIP_DOWNLOAD: "true"
+            - PUPPETEER_EXECUTABLE_PATH: /snap/chromium/current/bin/chromium.launcher
         override-build: |
             npm install -g yarn
             yarn install
@@ -31,7 +34,9 @@ parts:
             # this causes PROT_EXEC problem
             rm -f ./node_modules/puppeteer/.local-chromium/linux-*/chrome-linux/nacl_irt_*.nexe
             cp -a ./dist/. $SNAPCRAFT_PART_INSTALL/
-            cp -r ./node_modules $SNAPCRAFT_PART_INSTALL 
+            cp -r ./node_modules $SNAPCRAFT_PART_INSTALL
+        stage-snaps:
+            - chromium
         stage-packages:
             # dependencies required by chromium
             - libasound2
@@ -57,6 +62,8 @@ parts:
 apps:
     ght:
         command: ght
+        environment:
+            PUPPETEER_EXECUTABLE_PATH: $SNAP/bin/chromium.launcher
         plugs:
             - desktop
             - desktop-legacy


### PR DESCRIPTION
Fixes #195 

Solving some issues with the snapcraft.yaml which prevent `ght` from working on `arm64`.

This PR makes a couple of key changes:

- Ensure that the `chromium` snap is installed in the build environment, and that it's binary is used during the build process
- Stop the `puppeteer` package downloading its own `chromium` build (set `PUPPETEER_EXECUTABLE_PATH`)
- Stage the `chromium` snap
- Set the `PUPPETEER_EXECUTABLE_PATH` for the `ght` app
- Upgrade to `core22` to ensure that library versions match between `chromium` and `ght`

While the `amd64` version wasn't broken, this means that there is less divergence between builds across archs, and also means we always get the latest and greatest (security patched!) chromium from the snap store.