### PR TITLE
Fix the authentication check

### DIFF
--- a/src/auth/UbuntuSSO.ts
+++ b/src/auth/UbuntuSSO.ts
@@ -152,9 +152,9 @@ export default class UbuntuSSO extends Authentication {
             this.defaultFetchOptions,
         );
         const html = await response.text();
-        // if "Personal details" is present in the page
+        // if "this id is present in the page
         // that means that we are in the user details page
-        return html.match(/personal details/i);
+        return html.match(/id="account"/i);
     }
 
     private prompt(): Promise<{

--- a/src/core/Job.ts
+++ b/src/core/Job.ts
@@ -299,6 +299,7 @@ export default class Job {
 
         const body = await this.page.$("body");
         let innerHTML = await body?.evaluate((element) => element.innerHTML);
+        console.log(url, innerHTML);
         if (!innerHTML) throw new Error(`Jobs cannot be found from ${url}`);
 
         // Strip HTML markup around the JSON. For example: <pre>


### PR DESCRIPTION
## Done

I have updated the logged-in check to target an element ID which is only present if logged in and not text on the page which seems to have changed.  This caused the auth check to fail even if the login was successful.

## Todo 

This revealed that locally running `yarn run assign -i` now passes the auth check but hits a 429 Too Many Requests when loading any page on Greenhouse. We might need to contact Greenhouse support to see what is causing this.