### PR TITLE
feat: allow skipping jobs already assigned jobs

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -136,7 +136,8 @@ function makeProgram(): Command {
         .command("assign")
         .usage(
             "([-i | --interactive])" +
-                "\n\n Examples: \n\t ght assign --interactive",
+                "\n\n Examples: \n\t ght assign --interactive" +
+                " \n\t ght assign --interactive --unassigned",
         )
         .description(
             "Assign graders to written interviews for the jobs selected.\n" +
@@ -144,6 +145,12 @@ function makeProgram(): Command {
         )
         .addOption(
             new Option("-i, --interactive", "Enable interactive interface"),
+        )
+        .addOption(
+            new Option(
+                "-u, --unassigned",
+                "Only assign interviews that do not have an assignee enabled in ght-graders.yml",
+            ),
         )
         .action(async (options) => {
             await new AssignGradersController(program, options).run();

--- a/src/controllers/AssignGradersController.ts
+++ b/src/controllers/AssignGradersController.ts
@@ -14,11 +14,13 @@ import { join } from "path";
 
 export class AssignGradersController extends BaseController {
     private isInteractive: boolean;
+    private onlyUnassigned: boolean;
 
     constructor(command: Command, options: any) {
         super(command);
 
         this.isInteractive = options.interactive;
+        this.onlyUnassigned = options.unassigned;
     }
 
     /**
@@ -114,6 +116,7 @@ export class AssignGradersController extends BaseController {
             gradersCount,
             this.config.greenhouseUrl,
             stage,
+            this.onlyUnassigned,
         );
         await loadBalancer.execute();
 

--- a/src/controllers/BaseController.ts
+++ b/src/controllers/BaseController.ts
@@ -84,7 +84,7 @@ export abstract class BaseController {
 
         const browser = await Puppeteer.launch(options);
         const page = await browser.newPage();
-        // Set a sane user agent to avoid anti bot protections
+        // Set a standard browser user agent to avoid anti bot protections
         if (isDevelopment) {
             page.setUserAgent('Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36');
         }

--- a/src/controllers/BaseController.ts
+++ b/src/controllers/BaseController.ts
@@ -84,6 +84,10 @@ export abstract class BaseController {
 
         const browser = await Puppeteer.launch(options);
         const page = await browser.newPage();
+        // Set a sane user agent to avoid anti bot protections
+        if (isDevelopment) {
+            page.setUserAgent('Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36');
+        }
 
         return {
             browser,


### PR DESCRIPTION
This adds a `-u/--unassigned` flag to `ght assign` to allow for skipping reassignment of jobs that are already assigned. This is intended to avoid spamming interviewers when add a new candidate to the queue.

I've tested the following configs under the following scenarios:

* assigned count == configuration grader count (=> nothing changes)
* assigned count < configuration grader count (=> new interviewers assigned)
* assigned count > configuration grader count (=> new interviewers assigned)
```
"MyJob":
  Written Interview:
    - name: Grader1
      active: true
    - name: Grader2
      active: true
    - name: Grader3
      active: true
```

* one interview with Grader3 assigned => Grader1 or 2 are assigned (assuming 1 interview count)
```
"MyJob":
  Written Interview:
    - name: Grader1
      active: true
    - name: Grader2
      active: true
    - name: Grader3
      active: false
```

Fixes #235 