### PR TITLE
fix: a couple of blockers preventing the snap passing auto review

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -35,6 +35,10 @@ parts:
             rm -f ./node_modules/puppeteer/.local-chromium/linux-*/chrome-linux/nacl_irt_*.nexe
             cp -a ./dist/. $SNAPCRAFT_PART_INSTALL/
             cp -r ./node_modules $SNAPCRAFT_PART_INSTALL
+            # Chromium adds this smylink to the root system
+            rm $SNAPCRAFT_PART_INSTALL/usr/bin/xdg-email
+            # chromium also sets the permissions to use suid for user execution (r-sr-xr-x), this simplifies the permission (r-xr-xr-x)
+            chmod 555 $SNAPCRAFT_PART_INSTALL/usr/lib/chromium-browser/chrome-sandbox
         stage-snaps:
             - chromium
         stage-packages:


### PR DESCRIPTION
Fix the following errors from automated checks:
```
package contains external symlinks: usr/bin/xdg-email -> /usr/bin/xdg-open lint-snap-v2_external_symlinks
found errors in file output: unusual mode 'r-sr-xr-x' for entry './usr/lib/chromium-browser/chrome-sandbox' security-snap-v2_squashfs_files
```

It doesn't appear that `xdg-email` is used and `chrome-sandbox` permissions should work just as well updated to `r-xr-xr-x`.