### PR TITLE
snap: move to base: core24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ght",
-    "version": "1.9.1",
+    "version": "1.10.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ght",
-            "version": "1.9.1",
+            "version": "1.10.0",
             "license": "MIT",
             "dependencies": {
                 "@sentry/node": "7.88.0",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -2,12 +2,12 @@ name: ght
 version: "1.10.0"
 summary: Perform actions in Canonical's Greenhouse automatically.
 description: An automated browser that does a set of tasks on Canonical's Greenhouse dashboard without the need of interaction with the UI.
-base: core22
+base: core24
 confinement: strict
 grade: stable
-architectures:
-    - build-on: amd64
-    - build-on: arm64
+platforms:
+    amd64:
+    arm64:
 parts:
     node:
         plugin: dump


### PR DESCRIPTION
Since chromium snap moved to `base: core24`, `ght` has to also move to `core24` base, otherwise embedded chromium binary expects wrong libc.