### PR TITLE
wait for save before reloading page

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ght
-version: "1.11.0"
+version: "1.11.1"
 summary: Perform actions in Canonical's Greenhouse automatically.
 description: An automated browser that does a set of tasks on Canonical's Greenhouse dashboard without the need of interaction with the UI.
 base: core22

--- a/src/core/LoadBalancer.ts
+++ b/src/core/LoadBalancer.ts
@@ -217,11 +217,26 @@ export default class LoadBalancer {
                 comma = ", ";
             }
 
-            // Click save
+            // Click save and await POST response
+            // POST is to this endpoint:
+            // https://canonical.greenhouse.io/interviews/take_home_test/graders
+            await Promise.all([
+                this.page.waitForResponse(
+                    (response) =>
+                        response
+                            .url()
+                            .includes("/interviews/take_home_test/graders") &&
+                        response.request().method() === "POST",
+                ),
+                this.page.click("input[type='submit']#save_graders"),
+            ]);
+
+            // Wait for the modal to disappear
             await this.page.waitForSelector(
-                "input[type='submit']#save_graders",
+                "#edit_take_home_test_graders_modal",
+                { hidden: true, timeout: 10000 },
             );
-            await this.page.click("input[type='submit']#save_graders");
+
             this.allocationsCount++;
 
             this.spinner.stop();


### PR DESCRIPTION
## Rationale
Users have been experiencing issues with GHT assign where a success message is shown but graders are not actually assigned. We have tried numerous times to replicate, but to no avail. Despite this, we have noticed a potential area for improvement in the robustness of the code: we are awaiting a click on the "save" button, but we are not awaiting the resultant POST response. As a result, this PR is to include this wait. We now await the POST response as well as the closure of the edit modal before reloading the page.

## Done
- Added a Puppeteer `waitForResponse` call to await the POST response from clicking "save"
- Added a Puppeteer `waitForSelector` with `hidden: true` to wait for the edit modal to close

## QA
- Checkout this feature branch
- Run the assign functionality with `yarn dev assign -i`
- Ensure that graders are assigned successfully

## Issue/Card
[WD-15931](https://warthogs.atlassian.net/browse/WD-15931)

[WD-15931]: https://warthogs.atlassian.net/browse/WD-15931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ