### PR TITLE
Add Osaka back as the second largest city in Japan

### DIFF
--- a/src/__tests__/Job.test.ts
+++ b/src/__tests__/Job.test.ts
@@ -65,7 +65,7 @@ describe("Job tests", () => {
             expect(spinner.start).toHaveBeenCalledWith(
                 "Starting to create job posts.",
             );
-            expect(spinner.text).toEqual("217 of 217 job posts are created.");
+            expect(spinner.text).toEqual("218 of 218 job posts are created.");
             expect(spinner.stop).toHaveBeenCalledTimes(1);
         });
 

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -268,6 +268,7 @@ const REGIONS = {
         "Home based - Asia Pacific, Melbourne",
         "Home based - Asia Pacific, Mumbai",
         "Home based - Asia Pacific, Nagoya",
+        "Home based - Asia Pacific, Osaka",
         "Home based - Asia Pacific, Perth",
         "Home based - Asia Pacific, Pune",
         "Home based - Asia Pacific, Seoul",


### PR DESCRIPTION
It was accidentally removed at 7f2563ac84f2dc1c553a193556095bb371003aff