### PR TITLE
fix: Move screen recordings to snap user common

### DIFF
--- a/src/utils/screenRecorder.ts
+++ b/src/utils/screenRecorder.ts
@@ -26,8 +26,8 @@ export class ScreenRecorder {
         }
 
         // define output directory for recording file
-        const homeDir = process.env.SNAP_REAL_HOME || os.homedir();
-        const directory = join(homeDir, ".ght", "recordings");
+        const homeDir = process.env.SNAP_USER_COMMON || join(os.homedir(), ".ght");
+        const directory = join(homeDir, "recordings");
         if (!existsSync(directory)) {
             mkdirSync(directory, { recursive: true });
         }


### PR DESCRIPTION
Snaps do not have access to hidden folders inside the user's home directory, which causes the --record flag to result in a permission denied error. This moves the location of the screen recordings to the $SNAP_USER_COMMON directory (~/snap/ght/common/recordings) which the snap does have access to.

Fixes #253 