### PR TITLE
update POST request structure for duplicating job post

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ght",
-    "version": "1.10.0",
+    "version": "1.11.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ght",
-            "version": "1.10.0",
+            "version": "1.11.2",
             "license": "MIT",
             "dependencies": {
                 "@sentry/node": "7.88.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ght",
-    "version": "1.10.0",
+    "version": "1.11.2",
     "scripts": {
         "build": "tsc && cp package.json ght ./dist",
         "dev": "NODE_ENV=development ts-node ./src/index.ts",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ght
-version: "1.11.1"
+version: "1.11.2"
 summary: Perform actions in Canonical's Greenhouse automatically.
 description: An automated browser that does a set of tasks on Canonical's Greenhouse dashboard without the need of interaction with the UI.
 base: core22

--- a/src/core/JobPost.ts
+++ b/src/core/JobPost.ts
@@ -270,18 +270,18 @@ export default class JobPost {
         );
 
         // set the new location
-        jobApplication.job_post_location.text_value = location;
+        jobApplication.job_post_locations[0].text_value = location;
         if (
-            jobApplication.job_post_location.job_post_location_type.key !==
+            jobApplication.job_post_locations[0].job_post_location_type.key !==
             "FREE_TEXT"
         ) {
-            jobApplication.job_post_location.job_post_location_type = {
+            jobApplication.job_post_locations[0].job_post_location_type = {
                 id: 1,
                 name: "Free Text",
                 key: "FREE_TEXT",
             };
         }
-        jobApplication.job_post_location.custom_location = null;
+        jobApplication.job_post_locations[0].custom_location = null;
         // set the title
         jobApplication.title = jobPost.name;
 


### PR DESCRIPTION
## Rationale

We received multiple reports of locations on job posts replicated by GHT being empty. This started occurring approximately yesterday (January 13th, 2025).

Upon investigation, it appears that the POST request sent internally by Greenhouse to duplicate a job post (which we are spoofing on GHT to perform our duplication) has changed slightly. The `job_post_location` field of the `greenhouse_job_application` field in this POST request body has changed. It is now an array called `job_post_locations` instead.

Therefore, we need to update how we spoof this request in GHT as well.

## Done
- Update POST request structure to handle new `job_post_locations` field.

## QA
- Checkout this feature branch
- Comment out line 107 in `Job.ts` that marks job posts as live. This will make absolutely sure we do not set any test posts as live when testing.
- Run `yarn dev replicate -i`
- Select `[804] Dev - test 1` as the job to create job posts for
- Select `Dev - test 1` as the job post to copy
- Select any region (I picked `apac` but any would work)
- Select `No` for removing existing job posts (this doesn't matter hugely either way really)
- Wait until you see `1 of X job posts are created.`, indicating that at least one job post has been created. You can stop execution with `Ctrl+C` at this point.
- Navigate to the [list of job posts for Dev - test 1](https://canonical.greenhouse.io/plans/2044596/jobapp) again and ensure that there is a new post there above the "dsdsd" post, with a location properly set which corresponds to the region you selected. (i.e. if you selected `apac`, the post location should be something like "Home based - Asia Pacific, Adelaide").
- **N.B.** Of course if you waited for longer than 1 job post to be created before stopping execution (i.e. you saw like `3 of X job posts are created.` before hitting `Ctrl+C`, for example), then you should expect to see that many job posts (all with properly set locations) in the list of job posts.

## Issue/Card
[WD-18179](https://warthogs.atlassian.net/browse/WD-18179)

[WD-18179]: https://warthogs.atlassian.net/browse/WD-18179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ