### PR TITLE
feat: search `$HOME/.config/ght` for graders file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ght",
-    "version": "1.11.3",
+    "version": "1.11.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ght",
-            "version": "1.11.3",
+            "version": "1.11.4",
             "license": "MIT",
             "dependencies": {
                 "@sentry/node": "7.88.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ght",
-    "version": "1.11.3",
+    "version": "1.11.4",
     "scripts": {
         "build": "tsc && cp package.json ght ./dist",
         "dev": "NODE_ENV=development ts-node ./src/index.ts",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ght
-version: "1.11.3"
+version: "1.11.4"
 summary: Perform actions in Canonical's Greenhouse automatically.
 description: An automated browser that does a set of tasks on Canonical's Greenhouse dashboard without the need of interaction with the UI.
 base: core22

--- a/src/controllers/AssignGradersController.ts
+++ b/src/controllers/AssignGradersController.ts
@@ -2,7 +2,6 @@ import { BaseController } from "./BaseController";
 import { runPrompt } from "../utils/commandUtils";
 import Job from "../core/Job";
 import { UserError } from "../utils/processUtils";
-import config from "../config/Config";
 import { loadConfigFile } from "../utils/configUtils";
 import { GradersConfig, Grader, JobToAssign } from "../core/types";
 import LoadBalancer from "../core/LoadBalancer";
@@ -98,7 +97,7 @@ export class AssignGradersController extends BaseController {
             "ght-graders.yml",
         );
         const gradersConfig = loadConfigFile<GradersConfig>(gradersConfigPath);
-        if (!config) {
+        if (!gradersConfig) {
             throw new UserError("Unable to find list of graders");
         }
         const graders = this.createPool(gradersConfig, selectedJobs);

--- a/src/utils/configUtils.ts
+++ b/src/utils/configUtils.ts
@@ -6,6 +6,6 @@ export function loadConfigFile<T>(filePath: string): T {
         const config = yaml.load(fs.readFileSync(filePath, "utf8"));
         return config as T;
     } catch {
-        throw new Error("Unable to load config file");
+        throw new Error(`Unable to load config file: '${filePath}'`);
     }
 }


### PR DESCRIPTION
Since we already look for config files in
`$HOME/.config/ght` for other configuration, it
makes sense to also search there for grader
config.

This change is backward compatible, so that users
who already have their config in place at
`$HOME/ght-graders.yml` will be unaffected by the
change.

Also includes a couple of drive-by changes to
improve error reporting and make it more obvious
which files are missing in the case that `ght`
tries to load a non-existent file.