### PR TITLE
Accept the beforeunload handler and skip excessive reload of the original job post

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ght",
-    "version": "1.11.6",
+    "version": "1.11.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ght",
-            "version": "1.11.6",
+            "version": "1.11.7",
             "license": "MIT",
             "dependencies": {
                 "@sentry/node": "7.88.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ght",
-    "version": "1.11.6",
+    "version": "1.11.7",
     "scripts": {
         "build": "tsc && cp package.json ght ./dist",
         "dev": "NODE_ENV=development ts-node ./src/index.ts",

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: ght
-version: "1.11.6"
+version: "1.11.7"
 license: GPL-3.0
 summary: Perform actions in Canonical's Greenhouse automatically.
 description: An automated browser that does a set of tasks on Canonical's Greenhouse dashboard without the need of interaction with the UI.

--- a/src/controllers/BaseController.ts
+++ b/src/controllers/BaseController.ts
@@ -115,6 +115,16 @@ export abstract class BaseController {
             await this.screenRecorder.start();
         }
 
+        // url1("/jobapps/${jobPost.id}/edit") may have a
+        // beforeunload handler so accept the "Changes you made may
+        // not be saved" dialog since we are not editing anything
+        // but replicating the existing data only.
+        page.on("dialog", dialog => {
+            if (dialog.type() === "beforeunload") {
+                dialog.accept();
+            }
+        });
+
         return {
             browser,
             page,

--- a/src/core/JobPost.ts
+++ b/src/core/JobPost.ts
@@ -204,14 +204,6 @@ export default class JobPost {
         // second city and on so skip reloading.
         if (this.page.url() != url1) {
             await this.page.goto(url1);
-
-            // url1("/jobapps/${jobPost.id}/edit") may have a
-            // beforeunload handler so accept the "Changes you made may
-            // not be saved" dialog since we are not editing anything
-            // but replicating the existing data only.
-            const acceptBeforeUnload = dialog =>
-                dialog.type() === "beforeunload" && dialog.accept();
-            this.page.on("dialog", acceptBeforeUnload);
         }
 
         const element = await this.page.$("*[data-react-class='JobPostsForm']");

--- a/src/core/JobPost.ts
+++ b/src/core/JobPost.ts
@@ -199,7 +199,14 @@ export default class JobPost {
             this.config.greenhouseUrl,
             `/jobapps/${jobPost.id}/edit`,
         );
-        await this.page.goto(url1);
+
+        // The expected URL is already opened when replicating to the
+        // second city and on. Also, by skipping the excessive reloads,
+        // it avoids the beforeunload handler of the site too since we
+        // are not leaving the page quickly and frequently.
+        if (this.page.url() != url1) {
+            await this.page.goto(url1);
+        }
 
         const element = await this.page.$("*[data-react-class='JobPostsForm']");
         if (!element)

--- a/src/core/JobPost.ts
+++ b/src/core/JobPost.ts
@@ -201,11 +201,17 @@ export default class JobPost {
         );
 
         // The expected URL is already opened when replicating to the
-        // second city and on. Also, by skipping the excessive reloads,
-        // it avoids the beforeunload handler of the site too since we
-        // are not leaving the page quickly and frequently.
+        // second city and on so skip reloading.
         if (this.page.url() != url1) {
             await this.page.goto(url1);
+
+            // url1("/jobapps/${jobPost.id}/edit") may have a
+            // beforeunload handler so accept the "Changes you made may
+            // not be saved" dialog since we are not editing anything
+            // but replicating the existing data only.
+            const acceptBeforeUnload = dialog =>
+                dialog.type() === "beforeunload" && dialog.accept();
+            this.page.on("dialog", acceptBeforeUnload);
         }
 
         const element = await this.page.$("*[data-react-class='JobPostsForm']");


### PR DESCRIPTION
"/jobapps/${jobPost.id}/edit" may have a beforeunload handler so accept
the "Changes you made may not be saved" dialog since we are not editing
anything but replicating the existing data only.

Also, the expected URL is already opened when replicating to the second city and on. So we can skip excessive reloading.

Closes: #268